### PR TITLE
Use biosteam correlation methods for better code-reuse

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -78,6 +78,7 @@ html_css_files = ['css/qsdsan.css']
 intersphinx_mapping = {
 	'BioSTEAM': ('https://biosteam.readthedocs.io/en/latest', None),
 	'Thermosteam': ('https://thermosteam.readthedocs.io/en/latest', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
 	'chemicals': ('https://chemicals.readthedocs.io/en/latest', None),
     'SALib': ('https://salib.readthedocs.io/en/latest', None),
 }

--- a/qsdsan/stats.py
+++ b/qsdsan/stats.py
@@ -113,8 +113,8 @@ def get_correlation(model, input_x=None, input_y=None,
     :func:`scipy.stats.kstest`
     
     '''
-    if not isinstance(input_x, Iterable): input_x = (input_x,)
-    if not isinstance(input_y, Iterable): input_y = (input_y,)
+    if input_x and not isinstance(input_x, Iterable): input_x = (input_x,)
+    if input_y and not isinstance(input_y, Iterable): input_y = (input_y,)
     if nan_policy not in ('propagate', 'raise', 'omit'):
         raise ValueError(f"invalid nan_policy '{nan_policy}'; valid names are: "
                           "'omit', 'propagate', and 'raise'")


### PR DESCRIPTION
Hi Yalin,

This pull request implements changes to the get_correlation function for better code-reuse. The API is intact, so it should be compatible with any tests. This change also speeds up the get_correlation function significantly, although it didn't take that long to begin with (on the order of milliseconds).

Note that BioSTEAM has no plans to implement more complicated sensitivity analyses as part of it's API, but might include a tutorial on this down the line. 

Although BioSTEAM also has a sampling method for convenience, I made no changes to the qsdsan's `generate_samples` function as it doesn't accept the model object as a parameter.

Let me know what you think,
Thanks!