### PR TITLE
Remove unused DomainError in _components.py

### DIFF
--- a/qsdsan/_components.py
+++ b/qsdsan/_components.py
@@ -32,7 +32,6 @@ _num_component_properties = _component._num_component_properties
 _key_component_properties = _component._key_component_properties
 # _TMH = tmo.base.thermo_model_handle.ThermoModelHandle
 _PH = tmo.base.phase_handle.PhaseHandle
-DomainError = tmo.exceptions.DomainError
 
 
 # %%


### PR DESCRIPTION
Thermosteam recently removed DomainError from thermosteam/exceptions.py.