### PR TITLE
Update _components.py

### DIFF
--- a/qsdsan/_component.py
+++ b/qsdsan/_component.py
@@ -343,13 +343,11 @@ class Component(Chemical):
             else:
                 if self.measured_as in self.atoms:
                     i = 1/get_mass_frac(self.atoms)[self.measured_as]
-                    self._MW = self.chem_MW / i
                 elif self.measured_as == 'COD':
                     chem_charge = charge_from_formula(self.formula)
                     Cr2O7 = - cod_test_stoichiometry(self.atoms, chem_charge)['Cr2O7-2']
                     cod = Cr2O7 * 1.5 * molecular_weight({'O':2})
                     i = self.chem_MW/cod
-                    self._MW = cod
                 elif self.measured_as:
                     raise AttributeError(f'Must specify i_mass for component {self.ID} '
                                          f'measured as {self.measured_as}.')
@@ -439,23 +437,13 @@ class Component(Chemical):
         '''
         if measured_as:
             if not (measured_as in ('COD', *self.atoms) or 'i_'+measured_as in _num_component_properties):
-            # if measured_as == 'COD':
-            #     self._MW = molecular_weight({'O':2})
-            # elif measured_as in self.atoms or 'i_'+measured_as in _num_component_properties:
-            #     self._MW = molecular_weight({measured_as:1})
-            # else:
                 raise AttributeError(f"Component {self.ID} must be measured as "
                                      f"either COD or one of its constituent atoms, "
                                      f"if not as itself.")
-        # else:
-            # if self.atoms: self._MW = molecular_weight(self.atoms)
-            # else: self._MW = 1
-        self._MW = self.chem_MW
-
+        # self._MW = self.chem_MW
         if hasattr(self, '_measured_as'):
             if self._measured_as != measured_as:
                 self._convert_i_attr(measured_as)
-
         self._measured_as = measured_as
 
     formula = property(Chemical.formula.fget)

--- a/qsdsan/_component.py
+++ b/qsdsan/_component.py
@@ -185,8 +185,8 @@ class Component(Chemical):
 
     .. note::
 
-        [1] Element ratios like `i_C`, `i_N`, `i_P`, `i_K`, `i_Mg`, and `i_Ca` will
-        be calculated based on `formula` and `measured_as` if given; and the ratio
+        [1] Element contents like `i_C`, `i_N`, `i_P`, `i_K`, `i_Mg`, and `i_Ca` will
+        be calculated based on `formula` and `measured_as` if given; and the content value
         will be 1 if the component is measured as this element.
 
         [2] For fractions including `f_BOD5_COD`, `f_uBOD_COD`, and `f_Vmass_Totmass`,
@@ -194,7 +194,14 @@ class Component(Chemical):
 
         [3] If no formula or MW is provided, then MW of this component is assumed to
         1 to avoid ZeroDivisionError exception in calculation.
-
+        
+        [4] Molar flowrate of a component, if not given, will always be calculated 
+        using the mass flowrate data and the MW of this component. If `measured_as` 
+        is not `None`, i.e., the mass flowrate data is interpreted in the `measured_as` 
+        unit, the calculated molar flowrate would be inaccurate unless user adjusts
+        the MW value accordingly. However, this is irrelevant if the component itself
+        does not have a sensible MW anyway.  
+        
 
     Examples
     --------
@@ -237,7 +244,7 @@ class Component(Chemical):
         self._degradability = degradability
         self._organic = organic
         self.description = description
-        self._measured_as = measured_as
+        self.measured_as = measured_as
         self.i_mass = i_mass
         self.i_C = i_C
         self.i_N = i_N
@@ -336,16 +343,17 @@ class Component(Chemical):
             else:
                 if self.measured_as in self.atoms:
                     i = 1/get_mass_frac(self.atoms)[self.measured_as]
+                    self._MW = self.chem_MW / i
                 elif self.measured_as == 'COD':
-                    # chem_MW = molecular_weight(self.atoms)
                     chem_charge = charge_from_formula(self.formula)
                     Cr2O7 = - cod_test_stoichiometry(self.atoms, chem_charge)['Cr2O7-2']
                     cod = Cr2O7 * 1.5 * molecular_weight({'O':2})
-                    try: i = self.chem_MW/cod
-                    except: breakpoint()
+                    i = self.chem_MW/cod
+                    self._MW = cod
                 elif self.measured_as:
                     raise AttributeError(f'Must specify i_mass for component {self.ID} '
                                          f'measured as {self.measured_as}.')
+                
         if self.measured_as == None:
             if i and i != 1:
                 raise AttributeError(f'Component {self.ID} is measured as itself, '
@@ -430,21 +438,23 @@ class Component(Chemical):
         be automatically updated.
         '''
         if measured_as:
-            if measured_as == 'COD':
-                self._MW = molecular_weight({'O':2})
-            elif measured_as in self.atoms or 'i_'+measured_as in _num_component_properties:
-                self._MW = molecular_weight({measured_as:1})
-            else:
+            if not (measured_as in ('COD', *self.atoms) or 'i_'+measured_as in _num_component_properties):
+            # if measured_as == 'COD':
+            #     self._MW = molecular_weight({'O':2})
+            # elif measured_as in self.atoms or 'i_'+measured_as in _num_component_properties:
+            #     self._MW = molecular_weight({measured_as:1})
+            # else:
                 raise AttributeError(f"Component {self.ID} must be measured as "
                                      f"either COD or one of its constituent atoms, "
                                      f"if not as itself.")
-        else:
+        # else:
             # if self.atoms: self._MW = molecular_weight(self.atoms)
             # else: self._MW = 1
-            self._MW = self.chem_MW
+        self._MW = self.chem_MW
 
-        if self._measured_as != measured_as:
-            self._convert_i_attr(measured_as)
+        if hasattr(self, '_measured_as'):
+            if self._measured_as != measured_as:
+                self._convert_i_attr(measured_as)
 
         self._measured_as = measured_as
 
@@ -532,7 +542,12 @@ class Component(Chemical):
         return self._i_COD or 0.
     @i_COD.setter
     def i_COD(self, i):
-        if i is not None: self._i_COD = check_return_property('i_COD', i)
+        if i is not None: 
+            i = check_return_property('i_COD', i)
+            if self._measured_as == 'COD' and i != 1: 
+                warn(f'{self.ID} is measured as COD but `i_COD` is not 1, '
+                     '`<WasteStream>.COD` will yield inaccurate result.')
+            self._i_COD = i
         else:
             if self.organic or self.formula in ('H2', 'O2', 'N2', 'NO2-', 'NO3-', 'H2S', 'S'):
                 if self.measured_as == 'COD': self._i_COD = 1.

--- a/qsdsan/_component.py
+++ b/qsdsan/_component.py
@@ -185,8 +185,8 @@ class Component(Chemical):
 
     .. note::
 
-        [1] Element contents like `i_C`, `i_N`, `i_P`, `i_K`, `i_Mg`, and `i_Ca` will
-        be calculated based on `formula` and `measured_as` if given; and the content value
+        [1] Element ratios like `i_C`, `i_N`, `i_P`, `i_K`, `i_Mg`, and `i_Ca` will
+        be calculated based on `formula` and `measured_as` if given; and the ratio
         will be 1 if the component is measured as this element.
 
         [2] For fractions including `f_BOD5_COD`, `f_uBOD_COD`, and `f_Vmass_Totmass`,
@@ -194,14 +194,7 @@ class Component(Chemical):
 
         [3] If no formula or MW is provided, then MW of this component is assumed to
         1 to avoid ZeroDivisionError exception in calculation.
-        
-        [4] Molar flowrate of a component, if not given, will always be calculated 
-        using the mass flowrate data and the MW of this component. If `measured_as` 
-        is not `None`, i.e., the mass flowrate data is interpreted in the `measured_as` 
-        unit, the calculated molar flowrate would be inaccurate unless user adjusts
-        the MW value accordingly. However, this is irrelevant if the component itself
-        does not have a sensible MW anyway.  
-        
+
 
     Examples
     --------
@@ -244,7 +237,7 @@ class Component(Chemical):
         self._degradability = degradability
         self._organic = organic
         self.description = description
-        self.measured_as = measured_as
+        self._measured_as = measured_as
         self.i_mass = i_mass
         self.i_C = i_C
         self.i_N = i_N
@@ -344,6 +337,7 @@ class Component(Chemical):
                 if self.measured_as in self.atoms:
                     i = 1/get_mass_frac(self.atoms)[self.measured_as]
                 elif self.measured_as == 'COD':
+                    # chem_MW = molecular_weight(self.atoms)
                     chem_charge = charge_from_formula(self.formula)
                     Cr2O7 = - cod_test_stoichiometry(self.atoms, chem_charge)['Cr2O7-2']
                     cod = Cr2O7 * 1.5 * molecular_weight({'O':2})
@@ -351,7 +345,6 @@ class Component(Chemical):
                 elif self.measured_as:
                     raise AttributeError(f'Must specify i_mass for component {self.ID} '
                                          f'measured as {self.measured_as}.')
-                
         if self.measured_as == None:
             if i and i != 1:
                 raise AttributeError(f'Component {self.ID} is measured as itself, '
@@ -530,12 +523,7 @@ class Component(Chemical):
         return self._i_COD or 0.
     @i_COD.setter
     def i_COD(self, i):
-        if i is not None: 
-            i = check_return_property('i_COD', i)
-            if self._measured_as == 'COD' and i != 1: 
-                warn(f'{self.ID} is measured as COD but `i_COD` is not 1, '
-                     '`<WasteStream>.COD` will yield inaccurate result.')
-            self._i_COD = i
+        if i is not None: self._i_COD = check_return_property('i_COD', i)
         else:
             if self.organic or self.formula in ('H2', 'O2', 'N2', 'NO2-', 'NO3-', 'H2S', 'S'):
                 if self.measured_as == 'COD': self._i_COD = 1.

--- a/qsdsan/_component.py
+++ b/qsdsan/_component.py
@@ -185,8 +185,8 @@ class Component(Chemical):
 
     .. note::
 
-        [1] Element ratios like `i_C`, `i_N`, `i_P`, `i_K`, `i_Mg`, and `i_Ca` will
-        be calculated based on `formula` and `measured_as` if given; and the ratio
+        [1] Element contents like `i_C`, `i_N`, `i_P`, `i_K`, `i_Mg`, and `i_Ca` will
+        be calculated based on `formula` and `measured_as` if given; and the content value
         will be 1 if the component is measured as this element.
 
         [2] For fractions including `f_BOD5_COD`, `f_uBOD_COD`, and `f_Vmass_Totmass`,
@@ -195,7 +195,13 @@ class Component(Chemical):
         [3] If no formula or MW is provided, then MW of this component is assumed to
         1 to avoid ZeroDivisionError exception in calculation.
 
-
+        [4] Molar flowrate of a component, if not given, will always be calculated 
+        using the mass flowrate data and the MW of this component. If `measured_as` 
+        is not `None`, i.e., the mass flowrate data is interpreted in the `measured_as` 
+        unit, the calculated molar flowrate would be inaccurate unless user adjusts
+        the MW value accordingly. However, this is irrelevant if the component itself
+        does not have a sensible MW anyway.
+        
     Examples
     --------
     `Component <https://qsdsan.readthedocs.io/en/latest/tutorials/2_Component.html>`_
@@ -237,7 +243,7 @@ class Component(Chemical):
         self._degradability = degradability
         self._organic = organic
         self.description = description
-        self._measured_as = measured_as
+        self.measured_as = measured_as
         self.i_mass = i_mass
         self.i_C = i_C
         self.i_N = i_N
@@ -337,7 +343,6 @@ class Component(Chemical):
                 if self.measured_as in self.atoms:
                     i = 1/get_mass_frac(self.atoms)[self.measured_as]
                 elif self.measured_as == 'COD':
-                    # chem_MW = molecular_weight(self.atoms)
                     chem_charge = charge_from_formula(self.formula)
                     Cr2O7 = - cod_test_stoichiometry(self.atoms, chem_charge)['Cr2O7-2']
                     cod = Cr2O7 * 1.5 * molecular_weight({'O':2})
@@ -523,7 +528,12 @@ class Component(Chemical):
         return self._i_COD or 0.
     @i_COD.setter
     def i_COD(self, i):
-        if i is not None: self._i_COD = check_return_property('i_COD', i)
+        if i is not None: 
+            i = check_return_property('i_COD', i)
+            if self._measured_as == 'COD' and i != 1: 
+                warn(f'{self.ID} is measured as COD but `i_COD` is not 1, '
+                     '`<WasteStream>.COD` will yield inaccurate result.')
+            self._i_COD = i
         else:
             if self.organic or self.formula in ('H2', 'O2', 'N2', 'NO2-', 'NO3-', 'H2S', 'S'):
                 if self.measured_as == 'COD': self._i_COD = 1.

--- a/qsdsan/_components.py
+++ b/qsdsan/_components.py
@@ -188,6 +188,10 @@ class Components(Chemicals):
             Reference component (or chemical ID) for those with `particle_size` == 'Dissolved gas'.
         particulate_ref : obj or str
             Reference component (or chemical ID) for those with `particle_size` == 'Particulate'.
+        ignore_inaccurate_molar_weight : bool
+            Default is False, need to be manually set to True if having components
+            with `measured_as` attributes. This is to alert the users that
+            calculations for attributes using molecular weight will be inacurate.
 
         Examples
         --------
@@ -199,7 +203,7 @@ class Components(Chemicals):
         >>> Substrate = Component('Substrate', phase='s', measured_as='COD', i_mass=18.3/300,
         ...                       organic=True, particle_size='Particulate', degradability='Readily')
         >>> cmps = Components([X, X_inert, Substrate])
-        >>> cmps.default_compile()
+        >>> cmps.default_compile(ignore_inaccurate_molar_weight=True)
         >>> cmps
         CompiledComponents([X, X_inert, Substrate])
         '''

--- a/qsdsan/_components.py
+++ b/qsdsan/_components.py
@@ -232,7 +232,7 @@ class Components(Chemicals):
         >>> # knowing 1 mol acetate is equivalent to 2 mol of O2 demand
         >>> s1 = Stream('s1', Ac=60.052, Ac_as_COD=2 * 32, units='kg/hr')
         >>> s1.mass
-        sparse([60.052, 64.])
+        sparse([60.052, 64.   ])
         
         >>> # However, the calculated molar flow is inaccurate because the MW for Ac_as_COD
         >>> # is inconsistent with its `measured_as`. This also affects the

--- a/qsdsan/_components.py
+++ b/qsdsan/_components.py
@@ -169,7 +169,8 @@ class Components(Chemicals):
 
 
     def default_compile(self, lock_state_at='l',
-                        soluble_ref='Urea', gas_ref='CO2', particulate_ref='Stearin'):
+                        soluble_ref='Urea', gas_ref='CO2', particulate_ref='Stearin', 
+                        ignore_inaccurate_molar_weight=False):
         '''
         Auto-fill of the missing properties of the components and compile,
         boiling point (Tb) and molar volume (V) will be copied from the reference component,
@@ -261,7 +262,7 @@ class Components(Chemicals):
             # Copy all remaining properties from water
             cmp.copy_models_from(water)
         for cmp in self: cmp.default()
-        self.compile()
+        self.compile(ignore_inaccurate_molar_weight=ignore_inaccurate_molar_weight)
 
 
     @classmethod
@@ -398,8 +399,8 @@ class Components(Chemicals):
         new.append(H2O)
 
         if default_compile:
-            new.default_compile(lock_state_at='', particulate_ref='NaCl')
-            new.compile()
+            new.default_compile(lock_state_at='', particulate_ref='NaCl', ignore_inaccurate_molar_weight=True)
+            new.compile(ignore_inaccurate_molar_weight=True)
             # Add aliases
             new.set_alias('H2O', 'Water')
             # Pre-define groups
@@ -486,9 +487,9 @@ class Components(Chemicals):
         add_V_from_rho(cmps.P4O10, rho=2.39, rho_unit='g/mL') # http://www.chemspider.com/Chemical-Structure.14128.html
         try:
             for cmp in cmps: cmp.default()
-            cmps.compile()
+            cmps.compile(ignore_inaccurate_molar_weight=True)
         except RuntimeError: # cannot compile due to missing properties
-            cmps.default_compile(**default_compile_kwargs)
+            cmps.default_compile(ignore_inaccurate_molar_weight=True, **default_compile_kwargs)
         for k, v in aliases.items():
             cmps.set_alias(k, v)
         return cmps
@@ -611,7 +612,7 @@ class CompiledComponents(CompiledChemicals):
         for i in _num_component_properties:
             dct[i] = component_data_array(components, i)
 
-    def compile(self, skip_checks=False):
+    def compile(self, skip_checks=False, ignore_inaccurate_molar_weight=False):
         '''Do nothing, :class:`CompiledComponents` have already been compiled.'''
         pass
 
@@ -655,7 +656,7 @@ class CompiledComponents(CompiledChemicals):
         '''Create a new subgroup of :class:`Component` objects.'''
         components = self[IDs]
         new = Components(components)
-        new.compile()
+        new.compile(ignore_inaccurate_molar_weight=True)
         for i in new.IDs:
             for j in self.get_aliases(i):
                 try: new.set_alias(i, j)
@@ -682,7 +683,7 @@ class CompiledComponents(CompiledChemicals):
     def copy(self):
         '''Return a copy.'''
         copy = Components(self)
-        copy.compile()
+        copy.compile(ignore_inaccurate_molar_weight=True)
         return copy
 
 

--- a/qsdsan/_components.py
+++ b/qsdsan/_components.py
@@ -226,7 +226,7 @@ class Components(Chemicals):
         ...                       particle_size='Soluble', degradability='Readily', organic=True)
         >>> Acs = Components([Ac, Ac_as_COD])
         >>> Acs.default_compile(ignore_inaccurate_molar_weight=True, 
-                                adjust_MW_to_measured_as=False)
+        ...                     adjust_MW_to_measured_as=False)
         >>> set_thermo(Acs)
         >>> # Create a WasteStream object with 1 kmol/hr of each acetic acid component, 
         >>> # knowing 1 mol acetate is equivalent to 2 mol of O2 demand
@@ -240,7 +240,7 @@ class Components(Chemicals):
         >>> s1.mol
         sparse([1.   , 1.066])
         >>> s1.vol
-        sparse([0.062, 0.066]) # inaccurate calculation of volumetric flow
+        sparse([0.05 , 0.054])
         
         >>> # To fix the molar flow calculation, simply set `adjust_MW_to_measured_as` to True when compile.
         >>> Acs_MW_adjusted = Components([Ac, Ac_as_COD])
@@ -250,7 +250,7 @@ class Components(Chemicals):
         >>> s2.mol
         sparse([1., 1.])
         >>> s2.vol
-        sparse([0.062, 0.062])
+        sparse([0.05, 0.05])
         
         '''
         isa = isinstance

--- a/qsdsan/processes/_adm1.py
+++ b/qsdsan/processes/_adm1.py
@@ -169,7 +169,7 @@ def create_adm1_cmps(set_thermo=True):
                             S_ch4, S_IC, S_IN, S_I, X_c, X_ch, X_pr, X_li,
                             X_su, X_aa, X_fa, X_c4, X_pro, X_ac, X_h2, X_I,
                             S_cat, S_an, cmps_all.H2O])
-    cmps_adm1.default_compile()
+    cmps_adm1.default_compile(ignore_inaccurate_molar_weight=True)
     if set_thermo: settings.set_thermo(cmps_adm1)
     return cmps_adm1
 

--- a/qsdsan/processes/_adm1.py
+++ b/qsdsan/processes/_adm1.py
@@ -46,7 +46,7 @@ _load_components = settings.get_default_chemicals
 C_mw = 12
 N_mw = 14
 
-def create_adm1_cmps(set_thermo=True):
+def create_adm1_cmps(set_thermo=True, adjust_MW_to_measured_as=True):
     cmps_all = Components.load_default()
 
     # varies
@@ -169,7 +169,8 @@ def create_adm1_cmps(set_thermo=True):
                             S_ch4, S_IC, S_IN, S_I, X_c, X_ch, X_pr, X_li,
                             X_su, X_aa, X_fa, X_c4, X_pro, X_ac, X_h2, X_I,
                             S_cat, S_an, cmps_all.H2O])
-    cmps_adm1.default_compile(ignore_inaccurate_molar_weight=True)
+    cmps_adm1.default_compile(ignore_inaccurate_molar_weight=True,
+                              adjust_MW_to_measured_as=adjust_MW_to_measured_as)
     if set_thermo: settings.set_thermo(cmps_adm1)
     return cmps_adm1
 

--- a/qsdsan/processes/_adm1_p_extension.py
+++ b/qsdsan/processes/_adm1_p_extension.py
@@ -59,7 +59,7 @@ C_mw = get_mw({'C':1})
 N_mw = get_mw({'N':1})
 P_mw = get_mw({'P':1})
 
-def create_adm1_p_extension_cmps(set_thermo=True):
+def create_adm1_p_extension_cmps(set_thermo=True, adjust_MW_to_measured_as=True):
     c1 = create_adm1_cmps(False)
     c2d = create_masm2d_cmps(False)
     _c2 = create_asm2d_cmps(False)
@@ -75,7 +75,8 @@ def create_adm1_p_extension_cmps(set_thermo=True):
                             c2d.X_PHA, c2d.X_PP, c2d.X_PAO, 
                             c2d.S_K, c2d.S_Mg, _c2.X_MeOH, _c2.X_MeP,
                             *others])
-    cmps_adm1p.default_compile(ignore_inaccurate_molar_weight=True)
+    cmps_adm1p.default_compile(ignore_inaccurate_molar_weight=True,
+                               adjust_MW_to_measured_as=adjust_MW_to_measured_as)
     if set_thermo: settings.set_thermo(cmps_adm1p)
     return cmps_adm1p
 
@@ -546,7 +547,7 @@ class ADM1_p_extension(ADM1):
 # =============================================================================
 
 
-def create_adm1p_cmps(set_thermo=True):
+def create_adm1p_cmps(set_thermo=True, adjust_MW_to_measured_as=True):
     c1 = create_adm1_cmps(False)
     c2d = create_masm2d_cmps(False)
     
@@ -602,7 +603,8 @@ def create_adm1p_cmps(set_thermo=True):
                             c2d.X_struv, c2d.X_newb, c2d.X_ACP, c2d.X_MgCO3, 
                             c2d.X_AlOH, c2d.X_AlPO4, c2d.X_FeOH, c2d.X_FePO4, 
                             c2d.S_Na, c2d.S_Cl, c2d.H2O])
-    cmps_adm1p.default_compile(ignore_inaccurate_molar_weight=True)
+    cmps_adm1p.default_compile(ignore_inaccurate_molar_weight=True,
+                               adjust_MW_to_measured_as=adjust_MW_to_measured_as)
     if set_thermo: settings.set_thermo(cmps_adm1p)
     return cmps_adm1p
 

--- a/qsdsan/processes/_adm1_p_extension.py
+++ b/qsdsan/processes/_adm1_p_extension.py
@@ -75,7 +75,7 @@ def create_adm1_p_extension_cmps(set_thermo=True):
                             c2d.X_PHA, c2d.X_PP, c2d.X_PAO, 
                             c2d.S_K, c2d.S_Mg, _c2.X_MeOH, _c2.X_MeP,
                             *others])
-    cmps_adm1p.default_compile()
+    cmps_adm1p.default_compile(ignore_inaccurate_molar_weight=True)
     if set_thermo: settings.set_thermo(cmps_adm1p)
     return cmps_adm1p
 
@@ -602,7 +602,7 @@ def create_adm1p_cmps(set_thermo=True):
                             c2d.X_struv, c2d.X_newb, c2d.X_ACP, c2d.X_MgCO3, 
                             c2d.X_AlOH, c2d.X_AlPO4, c2d.X_FeOH, c2d.X_FePO4, 
                             c2d.S_Na, c2d.S_Cl, c2d.H2O])
-    cmps_adm1p.default_compile()
+    cmps_adm1p.default_compile(ignore_inaccurate_molar_weight=True)
     if set_thermo: settings.set_thermo(cmps_adm1p)
     return cmps_adm1p
 

--- a/qsdsan/processes/_asm1.py
+++ b/qsdsan/processes/_asm1.py
@@ -21,7 +21,7 @@ _path = ospath.join(data_path, 'process_data/_asm1.tsv')
 _load_components = settings.get_default_chemicals
 
 ############# Components with default notation #############
-def create_asm1_cmps(set_thermo=True):
+def create_asm1_cmps(set_thermo=True, adjust_MW_to_measured_as=True):
     cmps = Components.load_default()
 
     S_I = cmps.S_U_Inf.copy('S_I')
@@ -77,7 +77,7 @@ def create_asm1_cmps(set_thermo=True):
     cmps_asm1 = Components([S_I, S_S, X_I, X_S, X_BH, X_BA, X_P,
                             S_O, S_NO, S_NH, S_ND, X_ND, S_ALK,
                             cmps.S_N2, cmps.H2O])
-    cmps_asm1.compile(ignore_inaccurate_molar_weight=True)
+    cmps_asm1.compile(ignore_inaccurate_molar_weight=True, adjust_MW_to_measured_as=adjust_MW_to_measured_as)
     if set_thermo: settings.set_thermo(cmps_asm1)
 
     return cmps_asm1

--- a/qsdsan/processes/_asm1.py
+++ b/qsdsan/processes/_asm1.py
@@ -77,7 +77,7 @@ def create_asm1_cmps(set_thermo=True):
     cmps_asm1 = Components([S_I, S_S, X_I, X_S, X_BH, X_BA, X_P,
                             S_O, S_NO, S_NH, S_ND, X_ND, S_ALK,
                             cmps.S_N2, cmps.H2O])
-    cmps_asm1.compile()
+    cmps_asm1.compile(ignore_inaccurate_molar_weight=True)
     if set_thermo: settings.set_thermo(cmps_asm1)
 
     return cmps_asm1

--- a/qsdsan/processes/_asm2d.py
+++ b/qsdsan/processes/_asm2d.py
@@ -27,7 +27,7 @@ _path = ospath.join(data_path, 'process_data/_asm2d.tsv')
 _load_components = settings.get_default_chemicals
 
 ############# Components with default notation #############
-def create_asm2d_cmps(set_thermo=True):
+def create_asm2d_cmps(set_thermo=True, adjust_MW_to_measured_as=True):
     cmps = Components.load_default()
 
     S_A = cmps.S_Ac.copy('S_A')
@@ -69,12 +69,13 @@ def create_asm2d_cmps(set_thermo=True):
                              S_F, S_A, S_I, S_ALK, X_I, X_S, X_H, X_PAO, X_PP,
                              X_PHA, X_AUT, X_MeOH, X_MeP, cmps.H2O])
 
-    cmps_asm2d.compile(ignore_inaccurate_molar_weight=True)
+    cmps_asm2d.compile(ignore_inaccurate_molar_weight=True, 
+                       adjust_MW_to_measured_as=adjust_MW_to_measured_as)
     if set_thermo: settings.set_thermo(cmps_asm2d)
 
     return cmps_asm2d
 
-def create_masm2d_cmps(set_thermo=True):
+def create_masm2d_cmps(set_thermo=True, adjust_MW_to_measured_as=True):
     c2d = create_asm2d_cmps(False)
     ion_kwargs = dict(particle_size='Soluble',
                       degradability='Undegradable',
@@ -153,7 +154,8 @@ def create_masm2d_cmps(set_thermo=True):
     cmps = Components([*solubles, S_IC, S_K, S_Mg, *particulates, 
                        S_Ca, X_CaCO3, X_struv, X_newb, X_ACP, X_MgCO3, 
                        X_AlOH, X_AlPO4, X_FeOH, X_FePO4, S_Na, S_Cl, H2O])
-    cmps.default_compile(ignore_inaccurate_molar_weight=True)
+    cmps.default_compile(ignore_inaccurate_molar_weight=True, 
+                         adjust_MW_to_measured_as=adjust_MW_to_measured_as)
     if set_thermo: settings.set_thermo(cmps)
 
     return cmps

--- a/qsdsan/processes/_asm2d.py
+++ b/qsdsan/processes/_asm2d.py
@@ -69,7 +69,7 @@ def create_asm2d_cmps(set_thermo=True):
                              S_F, S_A, S_I, S_ALK, X_I, X_S, X_H, X_PAO, X_PP,
                              X_PHA, X_AUT, X_MeOH, X_MeP, cmps.H2O])
 
-    cmps_asm2d.compile()
+    cmps_asm2d.compile(ignore_inaccurate_molar_weight=True)
     if set_thermo: settings.set_thermo(cmps_asm2d)
 
     return cmps_asm2d
@@ -153,7 +153,7 @@ def create_masm2d_cmps(set_thermo=True):
     cmps = Components([*solubles, S_IC, S_K, S_Mg, *particulates, 
                        S_Ca, X_CaCO3, X_struv, X_newb, X_ACP, X_MgCO3, 
                        X_AlOH, X_AlPO4, X_FeOH, X_FePO4, S_Na, S_Cl, H2O])
-    cmps.default_compile()
+    cmps.default_compile(ignore_inaccurate_molar_weight=True)
     if set_thermo: settings.set_thermo(cmps)
 
     return cmps

--- a/qsdsan/processes/_pm2.py
+++ b/qsdsan/processes/_pm2.py
@@ -109,7 +109,7 @@ def create_pm2_cmps(set_thermo=True):
     cmps_pm2 = Components([X_CHL, X_ALG, X_PG, X_TAG, S_CO2, S_A, S_G,
                            S_O2, S_NH, S_NO, S_P, X_N_ALG, X_P_ALG, cmps.H2O])
 
-    cmps_pm2.default_compile()
+    cmps_pm2.default_compile(ignore_inaccurate_molar_weight=True)
 
     if set_thermo: settings.set_thermo(cmps_pm2)
     return cmps_pm2

--- a/qsdsan/processes/_pm2asm2d.py
+++ b/qsdsan/processes/_pm2asm2d.py
@@ -158,7 +158,7 @@ def create_pm2asm2d_cmps(set_thermo=True):
                            S_O2, S_NH, S_NO, S_P, X_N_ALG, X_P_ALG,
                            S_N2, S_ALK, S_I, X_I, X_S, X_H, X_AUT, cmps.H2O])
 
-    cmps_pm2asm2d.default_compile()
+    cmps_pm2asm2d.default_compile(ignore_inaccurate_molar_weight=True)
 
     if set_thermo: settings.set_thermo(cmps_pm2asm2d)
     return cmps_pm2asm2d

--- a/qsdsan/sanunits/_clarifier.py
+++ b/qsdsan/sanunits/_clarifier.py
@@ -1050,14 +1050,14 @@ class PrimaryClarifierBSM2(SanUnit):
         WasteStream-specific properties:
          pH         : 7.0
          Alkalinity : 2.5 mmol/L
-         COD        : 23873.0 mg/L
-         BOD        : 14963.2 mg/L
-         TC         : 8298.3 mg/L
-         TOC        : 8298.3 mg/L
-         TN         : 20363.2 mg/L
-         TP         : 367.6 mg/L
-         TK         : 68.3 mg/L
-         TSS        : 11124.4 mg/L
+         COD        : 23722.5 mg/L
+         BOD        : 14868.9 mg/L
+         TC         : 8245.9 mg/L
+         TOC        : 8245.9 mg/L
+         TN         : 20234.8 mg/L
+         TP         : 365.3 mg/L
+         TK         : 67.9 mg/L
+         TSS        : 11054.3 mg/L
     outs...
     [0] eff
     phase: 'l', T: 298.15 K, P: 101325 Pa
@@ -1067,14 +1067,14 @@ class PrimaryClarifierBSM2(SanUnit):
                     H2O    9.93e+05
         WasteStream-specific properties:
          pH         : 7.0
-         COD        : 15436.7 mg/L
-         BOD        : 10190.8 mg/L
-         TC         : 5208.2 mg/L
-         TOC        : 5208.2 mg/L
-         TN         : 19890.1 mg/L
-         TP         : 206.9 mg/L
-         TK         : 27.8 mg/L
-         TSS        : 4531.6 mg/L
+         COD        : 15338.9 mg/L
+         BOD        : 10126.2 mg/L
+         TC         : 5175.1 mg/L
+         TOC        : 5175.1 mg/L
+         TN         : 19764.1 mg/L
+         TP         : 205.6 mg/L
+         TK         : 27.6 mg/L
+         TSS        : 4502.9 mg/L
     [1] sludge
     phase: 'l', T: 298.15 K, P: 101325 Pa
     flow (g/hr): S_F    70
@@ -1083,14 +1083,14 @@ class PrimaryClarifierBSM2(SanUnit):
                     H2O    7e+03
         WasteStream-specific properties:
          pH         : 7.0
-         COD        : 693717.5 mg/L
-         BOD        : 393895.7 mg/L
-         TC         : 253653.4 mg/L
-         TOC        : 253653.4 mg/L
-         TN         : 57923.7 mg/L
-         TP         : 13132.3 mg/L
-         TK         : 3282.0 mg/L
-         TSS        : 534594.0 mg/L
+         COD        : 691249.2 mg/L
+         BOD        : 392494.2 mg/L
+         TC         : 252750.9 mg/L
+         TOC        : 252750.9 mg/L
+         TN         : 57717.6 mg/L
+         TP         : 13085.5 mg/L
+         TK         : 3270.3 mg/L
+         TSS        : 532691.9 mg/L
    
     References
     ----------
@@ -1259,59 +1259,11 @@ class PrimaryClarifier(IdealClarifier):
     ...                       isdynamic=True)
     >>> sys = System('sys', path=(PC,))
     >>> sys.simulate(t_span=(0,10), method='BDF')  # doctest: +ELLIPSIS
-    >>> PC.show() # doctest: +ELLIPSIS
-    PrimaryClarifier: PC
-    ins...
-    [0] ws
-    phase: 'l', T: 298.15 K, P: 101325 Pa
-    flow (g/hr): S_F    1e+04
-                    S_NH4  2e+04
-                    X_OHO  1.5e+04
-                    H2O    1e+06
-        WasteStream-specific properties:
-         pH         : 7.0
-         Alkalinity : 2.5 mmol/L
-         COD        : 23873.0 mg/L
-         BOD        : 14963.2 mg/L
-         TC         : 8298.3 mg/L
-         TOC        : 8298.3 mg/L
-         TN         : 20363.2 mg/L
-         TP         : 367.6 mg/L
-         TK         : 68.3 mg/L
-         TSS        : 11124.4 mg/L
-    outs...
-    [0] effluent
-    phase: 'l', T: 298.15 K, P: 101325 Pa
-    flow (g/hr): S_F    7e+03
-                    S_NH4  1.4e+04
-                    X_OHO  4.2e+03
-                    H2O    7.04e+05
-        WasteStream-specific properties:
-         pH         : 7.0
-         COD        : 15278.7 mg/L
-         BOD        : 10093.4 mg/L
-         TC         : 5152.8 mg/L
-         TOC        : 5152.8 mg/L
-         TN         : 19776.2 mg/L
-         TP         : 204.4 mg/L
-         TK         : 27.3 mg/L
-         TSS        : 4449.8 mg/L
-    [1] sludge
-    phase: 'l', T: 298.15 K, P: 101325 Pa
-    flow (g/hr): S_F    3e+03
-                    S_NH4  6e+03
-                    X_OHO  1.08e+04
-                    H2O    2.96e+05
-        WasteStream-specific properties:
-         pH         : 7.0
-         COD        : 43926.3 mg/L
-         BOD        : 26326.2 mg/L
-         TC         : 15637.8 mg/L
-         TOC        : 15637.8 mg/L
-         TN         : 21732.8 mg/L
-         TP         : 748.7 mg/L
-         TK         : 163.9 mg/L
-         TSS        : 26698.6 mg/L
+    >>> eff, sludge = PC.outs
+    >>> eff.get_TSS()/ws.get_TSS() # doctest: +ELLIPSIS
+    0.400...
+    >>> sludge.F_vol/ws.F_vol # doctest: +ELLIPSIS
+    0.300...
     
     References
     ----------

--- a/qsdsan/sanunits/_clarifier.py
+++ b/qsdsan/sanunits/_clarifier.py
@@ -1050,14 +1050,14 @@ class PrimaryClarifierBSM2(SanUnit):
         WasteStream-specific properties:
          pH         : 7.0
          Alkalinity : 2.5 mmol/L
-         COD        : 23722.5 mg/L
-         BOD        : 14868.9 mg/L
-         TC         : 8245.9 mg/L
-         TOC        : 8245.9 mg/L
-         TN         : 20234.8 mg/L
-         TP         : 365.3 mg/L
-         TK         : 67.9 mg/L
-         TSS        : 11054.3 mg/L
+         COD        : 23873.0 mg/L
+         BOD        : 14963.2 mg/L
+         TC         : 8298.3 mg/L
+         TOC        : 8298.3 mg/L
+         TN         : 20363.2 mg/L
+         TP         : 367.6 mg/L
+         TK         : 68.3 mg/L
+         TSS        : 11124.4 mg/L
     outs...
     [0] eff
     phase: 'l', T: 298.15 K, P: 101325 Pa
@@ -1067,14 +1067,14 @@ class PrimaryClarifierBSM2(SanUnit):
                     H2O    9.93e+05
         WasteStream-specific properties:
          pH         : 7.0
-         COD        : 15338.9 mg/L
-         BOD        : 10126.2 mg/L
-         TC         : 5175.1 mg/L
-         TOC        : 5175.1 mg/L
-         TN         : 19764.1 mg/L
-         TP         : 205.6 mg/L
-         TK         : 27.6 mg/L
-         TSS        : 4502.9 mg/L
+         COD        : 15436.7 mg/L
+         BOD        : 10190.8 mg/L
+         TC         : 5208.2 mg/L
+         TOC        : 5208.2 mg/L
+         TN         : 19890.1 mg/L
+         TP         : 206.9 mg/L
+         TK         : 27.8 mg/L
+         TSS        : 4531.6 mg/L
     [1] sludge
     phase: 'l', T: 298.15 K, P: 101325 Pa
     flow (g/hr): S_F    70
@@ -1083,14 +1083,14 @@ class PrimaryClarifierBSM2(SanUnit):
                     H2O    7e+03
         WasteStream-specific properties:
          pH         : 7.0
-         COD        : 691249.2 mg/L
-         BOD        : 392494.2 mg/L
-         TC         : 252750.9 mg/L
-         TOC        : 252750.9 mg/L
-         TN         : 57717.6 mg/L
-         TP         : 13085.5 mg/L
-         TK         : 3270.3 mg/L
-         TSS        : 532691.9 mg/L
+         COD        : 693717.5 mg/L
+         BOD        : 393895.7 mg/L
+         TC         : 253653.4 mg/L
+         TOC        : 253653.4 mg/L
+         TN         : 57923.7 mg/L
+         TP         : 13132.3 mg/L
+         TK         : 3282.0 mg/L
+         TSS        : 534594.0 mg/L
    
     References
     ----------
@@ -1259,11 +1259,59 @@ class PrimaryClarifier(IdealClarifier):
     ...                       isdynamic=True)
     >>> sys = System('sys', path=(PC,))
     >>> sys.simulate(t_span=(0,10), method='BDF')  # doctest: +ELLIPSIS
-    >>> eff, sludge = PC.outs
-    >>> eff.get_TSS()/ws.get_TSS() # doctest: +ELLIPSIS
-    0.400...
-    >>> sludge.F_vol/ws.F_vol # doctest: +ELLIPSIS
-    0.300...
+    >>> PC.show() # doctest: +ELLIPSIS
+    PrimaryClarifier: PC
+    ins...
+    [0] ws
+    phase: 'l', T: 298.15 K, P: 101325 Pa
+    flow (g/hr): S_F    1e+04
+                    S_NH4  2e+04
+                    X_OHO  1.5e+04
+                    H2O    1e+06
+        WasteStream-specific properties:
+         pH         : 7.0
+         Alkalinity : 2.5 mmol/L
+         COD        : 23873.0 mg/L
+         BOD        : 14963.2 mg/L
+         TC         : 8298.3 mg/L
+         TOC        : 8298.3 mg/L
+         TN         : 20363.2 mg/L
+         TP         : 367.6 mg/L
+         TK         : 68.3 mg/L
+         TSS        : 11124.4 mg/L
+    outs...
+    [0] effluent
+    phase: 'l', T: 298.15 K, P: 101325 Pa
+    flow (g/hr): S_F    7e+03
+                    S_NH4  1.4e+04
+                    X_OHO  4.2e+03
+                    H2O    7.04e+05
+        WasteStream-specific properties:
+         pH         : 7.0
+         COD        : 15278.7 mg/L
+         BOD        : 10093.4 mg/L
+         TC         : 5152.8 mg/L
+         TOC        : 5152.8 mg/L
+         TN         : 19776.2 mg/L
+         TP         : 204.4 mg/L
+         TK         : 27.3 mg/L
+         TSS        : 4449.8 mg/L
+    [1] sludge
+    phase: 'l', T: 298.15 K, P: 101325 Pa
+    flow (g/hr): S_F    3e+03
+                    S_NH4  6e+03
+                    X_OHO  1.08e+04
+                    H2O    2.96e+05
+        WasteStream-specific properties:
+         pH         : 7.0
+         COD        : 43926.3 mg/L
+         BOD        : 26326.2 mg/L
+         TC         : 15637.8 mg/L
+         TOC        : 15637.8 mg/L
+         TN         : 21732.8 mg/L
+         TP         : 748.7 mg/L
+         TK         : 163.9 mg/L
+         TSS        : 26698.6 mg/L
     
     References
     ----------

--- a/qsdsan/sanunits/_sludge_treatment.py
+++ b/qsdsan/sanunits/_sludge_treatment.py
@@ -489,7 +489,7 @@ class Incinerator(SanUnit):
     >>> cmps_test = qs.Components([cmps.S_F, cmps.S_NH4, cmps.X_OHO, cmps.H2O, 
     ...                            cmps.S_CH4, cmps.S_O2, cmps.S_N2, cmps.S_H2, 
     ...                            cmps.X_Ig_ISS, CO2])
-    >>> cmps_test.default_compile()
+    >>> cmps_test.default_compile(ignore_inaccurate_molar_weight=True)
     >>> qs.set_thermo(cmps_test)
     >>> ws = qs.WasteStream('ws', S_F=10, S_NH4=20, X_OHO=15, H2O=1000)
     >>> natural_gas = qs.WasteStream('nat_gas', phase='g', S_CH4=1000)

--- a/qsdsan/sanunits/_suspended_growth_bioreactor.py
+++ b/qsdsan/sanunits/_suspended_growth_bioreactor.py
@@ -857,7 +857,7 @@ class PFR(SanUnit):
     --------
     >>> import qsdsan.sanunits as su, qsdsan.processes as pc
     >>> from qsdsan import WasteStream
-    >>> cmps = pc.create_asm1_cmps()
+    >>> cmps = pc.create_asm1_cmps(adjust_MW_to_measured_as=False)
     >>> asm1 = pc.ASM1()
     >>> inf = WasteStream('inf', H2O=1.53e6, S_I=46, S_S=54, X_I=1770, X_S=230, 
     ...                   X_BH=3870, X_BA=225, X_P=680, S_O=0.377, S_NO=7.98, 
@@ -892,7 +892,7 @@ class PFR(SanUnit):
      WasteStream-specific properties:
       pH         : 7.0
       Alkalinity : 2.5 mmol/L
-      COD        : 4389.1 mg/L
+      COD        : 4389.0 mg/L
       BOD        : 1563.3 mg/L
       TC         : 1599.8 mg/L
       TOC        : 1550.1 mg/L
@@ -915,7 +915,7 @@ class PFR(SanUnit):
       X_ND   3.5
       S_ALK  49.7
       S_N2   13.7
-      H2O    994140.9
+      H2O    994138.1
   
     See Also
     --------

--- a/qsdsan/sanunits/_suspended_growth_bioreactor.py
+++ b/qsdsan/sanunits/_suspended_growth_bioreactor.py
@@ -883,7 +883,7 @@ class PFR(SanUnit):
                  X_P    6.95e+05
                  S_O    770
                  S_NO   1.6e+04
-                 S_NH   2.69e+03
+                 S_NH   2.68e+03
                  S_ND   1.06e+03
                  X_ND   5.42e+03
                  S_ALK  7.65e+04
@@ -892,22 +892,22 @@ class PFR(SanUnit):
      WasteStream-specific properties:
       pH         : 7.0
       Alkalinity : 2.5 mmol/L
-      COD        : 4387.5 mg/L
-      BOD        : 1562.7 mg/L
-      TC         : 1599.3 mg/L
-      TOC        : 1549.6 mg/L
-      TN         : 328.8 mg/L
+      COD        : 4389.1 mg/L
+      BOD        : 1563.3 mg/L
+      TC         : 1599.8 mg/L
+      TOC        : 1550.1 mg/L
+      TN         : 329.0 mg/L
       TP         : 68.2 mg/L
       TK         : 15.1 mg/L
-      TSS        : 3267.2 mg/L
+      TSS        : 3268.3 mg/L
      Component concentrations (mg/L):
       S_I    29.9
       S_S    1.5
-      X_I    1149.6
+      X_I    1150.0
       X_S    49.3
-      X_BH   2556.1
+      X_BH   2557.0
       X_BA   149.5
-      X_P    451.7
+      X_P    451.9
       S_O    0.5
       S_NO   10.4
       S_NH   1.7
@@ -915,7 +915,7 @@ class PFR(SanUnit):
       X_ND   3.5
       S_ALK  49.7
       S_N2   13.7
-      H2O    993864.4
+      H2O    994140.9
   
     See Also
     --------

--- a/qsdsan/sanunits/_suspended_growth_bioreactor.py
+++ b/qsdsan/sanunits/_suspended_growth_bioreactor.py
@@ -883,7 +883,7 @@ class PFR(SanUnit):
                  X_P    6.95e+05
                  S_O    770
                  S_NO   1.6e+04
-                 S_NH   2.68e+03
+                 S_NH   2.69e+03
                  S_ND   1.06e+03
                  X_ND   5.42e+03
                  S_ALK  7.65e+04
@@ -892,22 +892,22 @@ class PFR(SanUnit):
      WasteStream-specific properties:
       pH         : 7.0
       Alkalinity : 2.5 mmol/L
-      COD        : 4389.1 mg/L
-      BOD        : 1563.3 mg/L
-      TC         : 1599.8 mg/L
-      TOC        : 1550.1 mg/L
-      TN         : 329.0 mg/L
+      COD        : 4387.5 mg/L
+      BOD        : 1562.7 mg/L
+      TC         : 1599.3 mg/L
+      TOC        : 1549.6 mg/L
+      TN         : 328.8 mg/L
       TP         : 68.2 mg/L
       TK         : 15.1 mg/L
-      TSS        : 3268.3 mg/L
+      TSS        : 3267.2 mg/L
      Component concentrations (mg/L):
       S_I    29.9
       S_S    1.5
-      X_I    1150.0
+      X_I    1149.6
       X_S    49.3
-      X_BH   2557.0
+      X_BH   2556.1
       X_BA   149.5
-      X_P    451.9
+      X_P    451.7
       S_O    0.5
       S_NO   10.4
       S_NH   1.7
@@ -915,7 +915,7 @@ class PFR(SanUnit):
       X_ND   3.5
       S_ALK  49.7
       S_N2   13.7
-      H2O    994140.9
+      H2O    993864.4
   
     See Also
     --------

--- a/qsdsan/utils/doc_examples.py
+++ b/qsdsan/utils/doc_examples.py
@@ -87,7 +87,7 @@ def create_example_components(set_thermo=True):
     for cmp in cmps:
         cmp.default()
 
-    cmps.compile()
+    cmps.compile(ignore_inaccurate_molar_weight=True)
     cmps.set_synonym('H2O', 'Water')
     cmps.set_synonym('CH4', 'Methane')
     if set_thermo: qs_set_thermo(cmps)

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -54,16 +54,16 @@ def test_component():
     with pytest.raises(ValueError): # H2O already in default components
         cmps1.append(H2O)
     with pytest.raises(RuntimeError): # key chemical-related properties missing
-        cmps1.compile()
+        cmps1.compile(ignore_inaccurate_molar_weight=True)
     # Can compile with default-filling those missing properties
-    cmps1.default_compile(lock_state_at='', particulate_ref='NaCl')
+    cmps1.default_compile(lock_state_at='', particulate_ref='NaCl', ignore_inaccurate_molar_weight=True)
 
     cmps2 = Components((cmp for cmp in cmps1 if cmp.ID != 'H2O'))
     H2O = Component.from_chemical('H2O', Chemical('H2O'),
                                   particle_size='Soluble',
                                   degradability='Undegradable', organic=False)
     cmps2.append(H2O)
-    cmps2.default_compile(lock_state_at='', particulate_ref='NaCl')
+    cmps2.default_compile(lock_state_at='', particulate_ref='NaCl', ignore_inaccurate_molar_weight=True)
 
     cmps3 = Components.load_default()
     assert cmps3.S_H2.measured_as == 'COD'

--- a/tests/test_exposan.py
+++ b/tests/test_exposan.py
@@ -37,11 +37,6 @@ def test_exposan():
     bsm1_sys.simulate(t_span=(0,10), method='BDF')
     print(get_SRT(bsm1_sys, biomass_IDs=biomass_IDs['asm1'])) # to test the `get_SRT` function
 
-    #!!! Will use bsm2 to test the junction models
-    # from exposan.interface import create_system as create_inter_system
-    # sys_inter = create_inter_system()
-    # sys_inter.simulate(method='BDF', t_span=(0, 3)) # the default 'RK45' method can't solve it
-
     from exposan.cas import create_system as create_cas_system
     cas_sys = create_cas_system()
     cas_sys.simulate()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -57,7 +57,7 @@ def test_process():
     cmps_asm2d = Components([S_O2, S_F, S_A, S_NH4, S_NO3, S_PO4, S_I, S_ALK, S_N2,
                              X_I, X_S, X_H, X_PAO, X_PP, X_PHA, X_AUT, X_MeOH, X_MeP])
 
-    cmps_asm2d.compile()
+    cmps_asm2d.compile(ignore_inaccurate_molar_weight=True)
     set_thermo(cmps_asm2d)
 
     p1 = Process('aero_hydrolysis',


### PR DESCRIPTION
As mentioned in issue 100, I added a flag to the compile method. Now, components which have a measured_as property will not compile without switching the flag.