### PR TITLE
Flexible htl units

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ This document records notable changes to `QSDsan <https://github.com/QSD-Group/Q
 
 `1.6.0`_
 --------
+- Generalized :class:`~.unit_operations.HydrothermalLiquefaction` and :class:`~.unit_operations.Hydroprocessing` per `#125 <https://github.com/QSD-Group/QSDsan/issues/125>`_, also fixed some bugs.
+- Added a platform-wide test that any ``SanUnit`` declaring ``auxiliary_unit_names`` actually assigns every declared name, to catch this bug class generally. Original ``HydrothermalLiquefaction``, ``Hydrotreating``, and ``Hydrocracking`` were moved to ``exposan.htl`` as they are specific to that implementation.
+
 - Re-hosted the NJ Bioenergy web app under group-owned infrastructure: frontend at ``https://nj-bioenergy.apps.qsdsan.com`` (group Vercel) and backend at ``https://nj-bioenergy-api.apps.qsdsan.com`` (four AWS Lambda functions behind CloudFront). The old ``qsdsan.app`` address 301-redirects to the new frontend while the domain registration lapses.
 - Consolidated the standalone Jekyll website (formerly served at ``qsdsan.com``) into the Sphinx documentation, which now serves as the single canonical site.
 - Restyled the :ref:`Systems & Publications <systems>` page with a platform-and-methodology introduction (QSD, QSDsan, DMsan) and, for every entry, the full citation plus Read Paper / Source Code buttons; added a :ref:`Learning <learning>` page (workshops) and an :ref:`App <app>` page (web-app gallery).

--- a/docs/source/api/unit_operations/index.csv
+++ b/docs/source/api/unit_operations/index.csv
@@ -29,9 +29,8 @@ HeatExchangerNetwork,bst,No,:class:`bst/heat_exchanging/HeatExchangerNetwork <qs
 HXprocess,bst,No,:class:`bst/heat_exchanging/HXprocess <qsdsan.unit_operations.bst._heat_exchanging.HXprocess>`
 HXutility,bst,No,:class:`bst/heat_exchanging/HXutility <qsdsan.unit_operations.bst._heat_exchanging.HXutility>`
 HydraulicDelay,dynamic,Yes,:class:`dynamic/abstract/HydraulicDelay <qsdsan.unit_operations.dynamic._abstract.HydraulicDelay>`
-Hydrocracking,static,No,:class:`static/hydroprocessing/Hydrocracking <qsdsan.unit_operations.static._hydroprocessing.Hydrocracking>`
 HydrothermalLiquefaction,static,No,:class:`static/hydrothermal/HydrothermalLiquefaction <qsdsan.unit_operations.static._hydrothermal.HydrothermalLiquefaction>`
-Hydrotreating,static,No,:class:`static/hydroprocessing/Hydrotreating <qsdsan.unit_operations.static._hydroprocessing.Hydrotreating>`
+Hydroprocessing,static,No,:class:`static/hydroprocessing/Hydroprocessing <qsdsan.unit_operations.static._hydroprocessing.Hydroprocessing>`
 IdealClarifier,static,No,:class:`dynamic/clarifier/IdealClarifier <qsdsan.unit_operations.dynamic._clarifier.IdealClarifier>`
 IsothermalCompressor,bst,No,:class:`bst/compressor/IsothermalCompressor <qsdsan.unit_operations.bst._compressor.IsothermalCompressor>`
 Junction,dynamic,Yes,:class:`dynamic/junction/Junction <qsdsan.unit_operations.dynamic._junction.Junction>`

--- a/docs/source/api/unit_operations/static/index.rst
+++ b/docs/source/api/unit_operations/static/index.rst
@@ -121,8 +121,7 @@ G2RT
 
 Hydroprocessing
 ---------------
-:class:`~qsdsan.unit_operations.Hydrocracking`,
-:class:`~qsdsan.unit_operations.Hydrotreating`
+:class:`~qsdsan.unit_operations.Hydroprocessing`
 
 Hydrothermal
 ------------

--- a/qsdsan/unit_operations/static/__init__.py
+++ b/qsdsan/unit_operations/static/__init__.py
@@ -32,8 +32,8 @@ from ._g2rt import (
     UFMixer, VolumeReductionCombustor, VolumeReductionFilterPress,
     VRConcentrator, VRdryingtunnel, VRpasteurization,
 )
-from ._hydroprocessing import Hydrocracking, Hydrotreating
-from ._hydrothermal import CatalyticHydrothermalGasification, HydrothermalLiquefaction
+from ._hydroprocessing import Hydroprocessing
+from ._hydrothermal import CatalyticHydrothermalGasification, HydrothermalLiquefaction, KnockOutDrum
 from ._internal_circulation_rx import InternalCirculationRx
 from ._lagoon import Lagoon
 from ._membrane_distillation import MembraneDistillation
@@ -78,8 +78,8 @@ __all__ = (
     'mSCWOConcentratorModule', 'mSCWOGasModule', 'mSCWOReactorModule',
     'UFMixer', 'VolumeReductionCombustor', 'VolumeReductionFilterPress',
     'VRConcentrator', 'VRdryingtunnel', 'VRpasteurization',
-    'Hydrocracking', 'Hydrotreating',
-    'CatalyticHydrothermalGasification', 'HydrothermalLiquefaction',
+    'Hydroprocessing',
+    'CatalyticHydrothermalGasification', 'HydrothermalLiquefaction', 'KnockOutDrum',
     'InternalCirculationRx',
     'Lagoon',
     'MembraneDistillation',

--- a/qsdsan/unit_operations/static/_hydroprocessing.py
+++ b/qsdsan/unit_operations/static/_hydroprocessing.py
@@ -6,9 +6,9 @@ QSDsan: Quantitative Sustainable Design for sanitation and resource recovery sys
 
 This module is developed by:
 
-    Jianan Feng <jiananf2@illinois.edu>
-
     Yalin Li <mailto.yalin.li@gmail.com>
+
+    Jianan Feng <jiananf2@illinois.edu>
 
 This module is under the University of Illinois/NCSA Open Source License.
 Please refer to https://github.com/QSD-Group/QSDsan/blob/main/LICENSE.txt
@@ -19,9 +19,9 @@ from biosteam.units.decorators import cost
 from qsdsan import SanUnit, Stream, CEPCI_by_year
 from qsdsan.utils import auom
 from ._reactor import Reactor
-from ..bst import IsothermalCompressor, HXutility
+from ..bst import IsothermalCompressor, HXutility, HXprocess
 
-__all__ = ('Hydrocracking', 'Hydrotreating')
+__all__ = ('Hydroprocessing',)
 
 _lb_to_kg = auom('lb').conversion_factor('kg')
 _m3perh_to_mmscfd = 1/1177.17 # H2
@@ -30,120 +30,218 @@ _m3perh_to_mmscfd = 1/1177.17 # H2
 # %%
 
 # =============================================================================
-# HC
+# Hydroprocessing (general)
 # =============================================================================
 
-class Hydrocracking(Reactor):
+@cost(basis='Oil lb flowrate', ID='Hydrocracker', units='lb/hr',
+      cost=25e6, S=5963, CE=CEPCI_by_year[2007], n=0.75, BM=1)
+@cost(basis='Oil lb flowrate', ID='Hydrotreater', units='lb/hr',
+      cost=27e6, S=69637, CE=CEPCI_by_year[2007], n=0.68, BM=1)
+@cost(basis='PSA H2 lb flowrate', ID='PSA', units='lb/hr',
+      cost=1750000, S=5402, CE=CEPCI_by_year[2004], n=0.8, BM=2.47)
+class Hydroprocessing(Reactor):
     '''
-    Biocrude mixed with H2 are hydrotreated at elevated temperature (405°C)
-    and pressure to produce upgraded biooil. Co-product includes fuel gas.
-    
+    General fuel-upgrading reactor (hydrocracking, hydrotreating, or similar):
+    influent oil mixed with H2 reacts at elevated temperature and pressure to
+    produce a single upgraded effluent stream (mixed gas/oil/aqueous phases,
+    blended per `gas_yield`/`oil_yield`/`aq_yield` and their respective
+    composition dicts). Co-product includes spent catalyst.
+
+    **On reaction exotherm:** this class does NOT credit the hydroprocessing
+    reaction's own exotherm against `inf_hx`'s heating duty by default --
+    `inf_hx` costs the full sensible heat needed to bring both the influent
+    oil and hydrogen up to `T` (see `inf_T` below for the opt-in mechanism to
+    change this). This is a deliberate choice because this class's
+    yields/compositions (`gas_yield`/`oil_yield`/`aqueous_composition`/etc.)
+    are empirically-fit mass fractions across many named product species, not
+    derived from a mass/atom-balanced stoichiometric reaction. Therefore,
+    computing the reaction's real heat of reaction from
+    each component's tabulated heat of formation (`self.Hnet`) is not
+    reliable. If a more accurate influent temperature is known,
+    supply it via `inf_T` instead.
+
     Parameters
     ----------
     ins : Iterable(stream)
-        heavy_oil, hydrogen, catalyst_in.
+        Influent oil, hydrogen, catalyst_in.
     outs : Iterable(stream)
-        hc_out, catalyst_out.
-    WHSV: float
-        Weight Hourly Space velocity, [kg feed/hr/kg catalyst].
-    catalyst_lifetime: float
-        HC catalyst lifetime, [hr].
+        Effluent (oil + gas + aqueous, blended), catalyst_out.
+    T : float
+        Reaction temperature, [K].
+    P : float
+        Reaction pressure, [Pa]; also the hydrogen compressor's target pressure.
+    inf_T : float or None
+        Influent preheat temperature, [K]; if provided, both the oil and
+        hydrogen streams (fresh + recycled) are heated only to `inf_T`
+        (not `T`) before entering the reactor, and the remaining temperature
+        rise from `inf_T` to `T` is treated as coming from the reaction's own
+        heat of reaction (uncosted). Defaults to `None` (no credit; both streams effectively heated
+        straight to `T`, matching this class's historical behavior).
+    WHSV : float
+        Weight hourly space velocity, [kg feed/hr/kg catalyst].
+    catalyst_lifetime : float
+        Catalyst lifetime, [hr].
     catalyst_ID : str
         ID of the catalyst.
-    hydrogen_P: float
-        Hydrogen pressure, [Pa].
-    hydrogen_rxned_to_inf_oil: float
+    hydrogen_rxned_to_inf_oil : float
         Reacted H2 to influent oil mass ratio.
-    hydrogen_excess: float
-        Actual hydrogen amount = hydrogen_rxned_to_biocrude*hydrogen_excess
-    oil_yield: float
-        Mass ratio of cracked oil to the sum of heavy oil and reacted H2,
-        gas yield is calculated as 1-oil_yield (about 100% conversion as in [1]).
-    HCin_T: float
-        HC influent temperature, [K].
-    HCrxn_T: float
-        HC effluent (after reaction) temperature, [K].
-    gas_composition: dict
-        Composition of the gas products, will be normalized to 100% sum.
-    oil_composition: dict
-        Composition of the cracked oil, will be normalized to 100% sum.
-        
+    hydrogen_ratio : float
+        Total hydrogen amount = hydrogen_rxned_to_inf_oil * hydrogen_ratio;
+        excess hydrogen not recovered by the (optional) PSA leaves with the effluent.
+    include_PSA : bool
+        Whether to include a pressure swing adsorption (PSA) unit to recover excess H2.
+    PSA_efficiency : float
+        H2 recovery efficiency of the PSA unit; forced to 0 if `include_PSA` is False.
+    gas_yield : float
+        Mass ratio of fuel gas to the sum of influent oil and reacted H2.
+    oil_yield : float
+        Mass ratio of treated oil to the sum of influent oil and reacted H2.
+    gas_composition : dict
+        Composition of the gas fraction (excluding excess H2), normalized to 100% sum.
+    oil_composition : dict
+        Composition of the treated-oil fraction, normalized to 100% sum.
+    aqueous_composition : dict
+        Composition of the aqueous fraction, normalized to 100% sum.
+    internal_heat_exchanging : bool
+        If True, use the effluent to preheat the influent before the reactor.
+    use_decorated_cost : str
+        `'Hydrocracker'` or `'Hydrotreater'` to use the corresponding literature
+        decorated cost; any other value uses generic `Reactor`/`PressureVessel` costing.
+
+    Examples
+    --------
+    >>> from qsdsan import Component, Components, set_thermo, Stream
+    >>> from qsdsan.unit_operations import Hydroprocessing
+    >>> catalyst = Component('Catalyst', phase='s', particle_size='Particulate',
+    ...                       degradability='Undegradable', organic=False, formula='Al2O3')
+    >>> _ = catalyst.default()
+    >>> cmps = Components([
+    ...     Component('Octane', search_ID='Octane', particle_size='Soluble',
+    ...                degradability='Slowly', organic=True),
+    ...     Component('CH4', phase='g', particle_size='Dissolved gas',
+    ...                degradability='Slowly', organic=True),
+    ...     Component('CO2', phase='g', particle_size='Dissolved gas',
+    ...                degradability='Undegradable', organic=False),
+    ...     Component('H2', phase='g', particle_size='Dissolved gas',
+    ...                degradability='Undegradable', organic=False),
+    ...     Component('H2O', particle_size='Soluble', degradability='Undegradable',
+    ...                organic=False),
+    ...     catalyst,
+    ...     ])
+    >>> cmps.compile()
+    >>> set_thermo(cmps)
+    >>> oil = Stream('oil', Octane=100, units='kg/hr')
+    >>> H2 = Stream('H2')
+    >>> catalyst_in = Stream('catalyst_in', Catalyst=1, units='kg/hr', phase='s')
+    >>> U1 = Hydroprocessing('U1', ins=(oil, H2, catalyst_in), outs=('eff', 'catalyst_out'),
+    ...                      catalyst_ID='Catalyst',
+    ...                      gas_composition={'CO2': 0.5, 'CH4': 0.5},
+    ...                      oil_composition={'Octane': 1},
+    ...                      aqueous_composition={'H2O': 1})
+    >>> U1.simulate()
+    >>> round(U1.oil_yield + U1.gas_yield + U1.aq_yield, 6)
+    1.0
+    >>> sorted(set(type(u).__name__ for u in U1.auxiliary_units))
+    ['HXprocess', 'HXutility', 'IsothermalCompressor']
+
+    See Also
+    --------
+    `saf systems <https://github.com/QSD-Group/EXPOsan/tree/main/exposan/saf>`_
+
     References
     ----------
-    [1] Jones, S. B.; Zhu, Y.; Anderson, D. B.; Hallen, R. T.; Elliott, D. C.; 
-        Schmidt, A. J.; Albrecht, K. O.; Hart, T. R.; Butcher, M. G.; Drennan, C.; 
-        Snowden-Swan, L. J.; Davis, R.; Kinchin, C. 
+    [1] Jones, S. B.; Zhu, Y.; Anderson, D. B.; Hallen, R. T.; Elliott, D. C.;
+        Schmidt, A. J.; Albrecht, K. O.; Hart, T. R.; Butcher, M. G.; Drennan, C.;
+        Snowden-Swan, L. J.; Davis, R.; Kinchin, C.
         Process Design and Economics for the Conversion of Algal Biomass to
         Hydrocarbons: Whole Algae Hydrothermal Liquefaction and Upgrading;
         PNNL--23227, 1126336; 2014; https://doi.org/10.2172/1126336.
     '''
     _N_ins = 3
     _N_outs = 2
-    
-    auxiliary_unit_names=('compressor','heat_exchanger',)
-    
-    _F_BM_default = {**Reactor._F_BM_default,
-                     'Heat exchanger': 3.17,
-                     'Compressor': 1.1}
-    
+    _units = {
+        'Oil lb flowrate': 'lb/hr',
+        'PSA H2 lb flowrate': 'lb/hr',
+        }
+    _F_BM_default = {
+        **Reactor._F_BM_default,
+        'Heat exchanger': 3.17,
+        'Compressor': 1.1,
+        }
+    auxiliary_unit_names = ('compressor', 'hx', 'inf_hx', 'inf_hx_H2')
+
     def __init__(self, ID='', ins=None, outs=(), thermo=None,
                  init_with='Stream',
                  include_construction=False,
-                 WHSV=0.625, # wt./hr per wt. catalyst [1]
-                 catalyst_lifetime=5*7920, # 5 years [1]
+                 T=451+273.15,
+                 P=1034.7*6894.76,
+                 inf_T=None,
+                 WHSV=0.625,
+                 catalyst_lifetime=5*7920,
                  catalyst_ID='HC_catalyst',
-                 hydrogen_P=1039.7*6894.76,
                  hydrogen_rxned_to_inf_oil=0.01125,
-                 hydrogen_excess=5.556,
-                 oil_yield=1-0.03880-0.00630, 
-                 HCin_T=394+273.15,
-                 HCrxn_T=451+273.15,
-                 gas_composition={'CO2':0.03880, 'CH4':0.00630,},
+                 hydrogen_ratio=5.556,
+                 include_PSA=False,
+                 PSA_efficiency=0.9,
+                 gas_yield=0.03880+0.00630, # gas_yield = 1 - oil_yield
+                 oil_yield=1-0.03880-0.00630,
+                 gas_composition={'CO2': 0.03880, 'CH4': 0.00630},
                  oil_composition={
-                    'CYCHEX':0.03714, 'HEXANE':0.01111,
-                    'HEPTANE':0.11474, 'OCTANE':0.08125,
-                    'C9H20':0.09086, 'C10H22':0.11756,
-                    'C11H24':0.16846, 'C12H26':0.13198,
-                    'C13H28':0.09302, 'C14H30':0.04643,
-                    'C15H32':0.03250, 'C16H34':0.01923,
-                    'C17H36':0.00431, 'C18H38':0.00099,
-                    'C19H40':0.00497, 'C20H42':0.00033,
-                    },
-                 #combine C20H42 and PHYTANE as C20H42
-                 # will not be a variable in uncertainty/sensitivity analysis
-                 P=None, tau=5, void_fraciton=0.4, # Towler
+                     'CYCHEX': 0.03714, 'HEXANE': 0.01111,
+                     'HEPTANE': 0.11474, 'OCTANE': 0.08125,
+                     'C9H20': 0.09086, 'C10H22': 0.11756,
+                     'C11H24': 0.16846, 'C12H26': 0.13198,
+                     'C13H28': 0.09302, 'C14H30': 0.04643,
+                     'C15H32': 0.03250, 'C16H34': 0.01923,
+                     'C17H36': 0.00431, 'C18H38': 0.00099,
+                     'C19H40': 0.00497, 'C20H42': 0.00033,
+                     },
+                 aqueous_composition={'H2O': 1},
+                 internal_heat_exchanging=True,
+                 use_decorated_cost='Hydrocracker',
+                 dynamic_V_wf=False,
+                 tau=5, V_wf=0.4,
                  length_to_diameter=2, diameter=None,
-                 N=None, V=None, auxiliary=False, mixing_intensity=None, kW_per_m3=0,
+                 N=None, V=None, auxiliary=False,
+                 mixing_intensity=None, kW_per_m3=0,
                  wall_thickness_factor=1.5,
                  vessel_material='Stainless steel 316',
-                 vessel_type='Vertical'):
-        
+                 vessel_type='Vertical',
+                 ):
+
         SanUnit.__init__(self, ID, ins, outs, thermo, init_with, include_construction=include_construction)
+        self.T = T
+        self.P = P
+        self.inf_T = inf_T
         self.WHSV = WHSV
         self.catalyst_lifetime = catalyst_lifetime
         self.catalyst_ID = catalyst_ID
-        self.hydrogen_P = hydrogen_P
         self.hydrogen_rxned_to_inf_oil = hydrogen_rxned_to_inf_oil
-        self.hydrogen_excess = hydrogen_excess
+        self.hydrogen_ratio = hydrogen_ratio
+        self.include_PSA = include_PSA
+        self.PSA_efficiency = PSA_efficiency
+        self.gas_yield = gas_yield
         self.oil_yield = oil_yield
-        self.HCin_T = HCin_T
-        self._mixed_in = Stream(f'{ID}_mixed_in')
-        self.HCrxn_T = HCrxn_T
         self.gas_composition = gas_composition
         self.oil_composition = oil_composition
+        self.aqueous_composition = aqueous_composition
+        self.internal_heat_exchanging = internal_heat_exchanging
         IC_in = Stream(f'{ID}_IC_in')
         IC_out = Stream(f'{ID}_IC_out')
-        self.compressor = IsothermalCompressor(ID=f'.{ID}_IC', ins=IC_in,
-                                               outs=IC_out, P=None)
-        hx_H2_in = Stream(f'{ID}_hx_H2_in')
-        hx_H2_out = Stream(f'{ID}_hx_H2_out')
-        self.heat_exchanger_H2 = HXutility(ID=f'.{ID}_hx_H2', ins=hx_H2_in, outs=hx_H2_out)
-        hx_oil_in = Stream(f'{ID}_hx_oil_in')
-        hx_oil_out = Stream(f'{ID}_hx_oil_out')
-        self.heat_exchanger_oil = HXutility(ID=f'.{ID}_hx_oil', ins=hx_oil_in, outs=hx_oil_out)
-        self.P = P
+        self.compressor = IsothermalCompressor(ID=f'.{ID}_IC', ins=IC_in, outs=IC_out, P=P)
+        inf_pre_hx = Stream(f'{ID}_inf_pre_hx')
+        eff_pre_hx = Stream(f'{ID}_eff_pre_hx')
+        inf_after_hx = Stream(f'{ID}_inf_after_hx')
+        eff_after_hx = Stream(f'{ID}_eff_after_hx')
+        self.hx = HXprocess(ID=f'.{ID}_hx', ins=(inf_pre_hx, eff_pre_hx), outs=(inf_after_hx, eff_after_hx))
+        inf_hx_out = Stream(f'{ID}_inf_hx_out')
+        self.inf_hx = HXutility(ID=f'.{ID}_inf_hx', ins=inf_after_hx, outs=inf_hx_out, T=T, rigorous=True)
+        inf_hx_H2_out = Stream(f'{ID}_inf_hx_H2_out')
+        self.inf_hx_H2 = HXutility(ID=f'.{ID}_inf_hx_H2', ins=Stream(f'{ID}_inf_hx_H2_in'), outs=inf_hx_H2_out, T=T, rigorous=True)
+        self.use_decorated_cost = use_decorated_cost
+        self.dynamic_V_wf = dynamic_V_wf
         self.tau = tau
-        self.void_fraciton = void_fraciton
+        self.V_wf = V_wf
         self.length_to_diameter = length_to_diameter
         self.diameter = diameter
         self.N = N
@@ -154,430 +252,231 @@ class Hydrocracking(Reactor):
         self.wall_thickness_factor = wall_thickness_factor
         self.vessel_material = vessel_material
         self.vessel_type = vessel_type
-        
+
     def _run(self):
-        
-        heavy_oil, hydrogen, catalyst_in = self.ins
-        hc_out, catalyst_out = self.outs
-        
-        catalyst_in.imass[self.catalyst_ID] = heavy_oil.F_mass/self.WHSV/self.catalyst_lifetime
+        inf_oil, makeup_hydrogen, catalyst_in = self.ins
+        eff_oil, catalyst_out = self.outs
+
+        catalyst_in.imass[self.catalyst_ID] = inf_oil.F_mass/self.WHSV/self.catalyst_lifetime
         catalyst_in.phase = 's'
         catalyst_out.copy_like(catalyst_in)
-        # catalysts amount is quite low compared to the main stream, therefore do not consider
-        # heating/cooling of catalysts
-        
+
         hydrogen_rxned_to_inf_oil = self.hydrogen_rxned_to_inf_oil
-        hydrogen.imass['H2'] = heavy_oil.F_mass*hydrogen_rxned_to_inf_oil*self.hydrogen_excess
-        hydrogen.phase = 'g'
+        hydrogen_ratio = self.hydrogen_ratio
+        H2_rxned = inf_oil.F_mass * hydrogen_rxned_to_inf_oil
+        H2_tot = H2_rxned * hydrogen_ratio
+        H2_residual = self._H2_residual = H2_tot - H2_rxned
+        H2_recycled = self._H2_recycled = H2_residual * self.PSA_efficiency
+        H2_wasted = H2_residual - H2_recycled
 
-        hydrocarbon_mass = heavy_oil.F_mass*(1 + hydrogen_rxned_to_inf_oil)
-        # 100 wt% of heavy oil and reacted H2
-        # nearly all input heavy oils and H2 will be converted to products [1]
-        # spreadsheet HC calculation
-        hc_out.phase = 'g'
-        
-        for name, ratio in self.HC_composition.items():
-            hc_out.imass[name] = hydrocarbon_mass*ratio
-        
-        hc_out.imass['H2'] = heavy_oil.F_mass*hydrogen_rxned_to_inf_oil*(self.hydrogen_excess - 1)
-        
-        hc_out.P = heavy_oil.P
-        hc_out.T = self.HCrxn_T
-        
-        hc_out.vle(T=hc_out.T, P=hc_out.P)
+        eff_oil.copy_like(inf_oil)
+        eff_oil.phase = inf_oil.phase
+        eff_oil.empty()
+        eff_oil.imass[self.eff_composition.keys()] = self.eff_composition.values()
+        eff_oil.F_mass = inf_oil.F_mass*(1 + hydrogen_rxned_to_inf_oil)
+        eff_oil.imass['H2'] = H2_wasted
+        eff_oil.P = self.P
+        eff_oil.T = self.T
+        eff_oil.vle(T=eff_oil.T, P=eff_oil.P)
 
-        cmps = self.components
-        C_in = 0
-        total_num = len(list(cmps))
-        for num in range(total_num):
-            C_in += heavy_oil.imass[str(list(cmps)[num])]*list(cmps)[num].i_C
-            
-        C_out = self.hydrocarbon_C
-        
-        if C_out < 0.95*C_in or C_out > 1.05*C_out :
-            raise Exception('carbon mass balance is out of +/- 5% for HC')
-        # make sure that carbon mass balance is within +/- 5%. Otherwise, an
-        # exception will be raised.
-        
+        makeup_hydrogen.imass['H2'] = H2_rxned + H2_wasted
+        makeup_hydrogen.phase = 'g'
+
+    def _design(self):
+        Design = self.design_results
+        Design.clear()
+        Design['PSA H2 lb flowrate'] = self._H2_residual / _lb_to_kg
+        # Keep `recycled` in kg/hr for the mass balance below; only convert
+        # to lb/hr for the Design report entry.
+        recycled = self._H2_recycled
+        Design['H2 recycled'] = recycled / _lb_to_kg
+        Design['Oil lb flowrate'] = self.ins[0].F_mass/_lb_to_kg
+
+        IC = self.compressor
+        H2 = self.ins[1]
+        IC_ins0, IC_outs0 = IC.ins[0], IC.outs[0]
+        IC_ins0.copy_like(H2)
+        IC_ins0.F_mass += recycled
+        IC_outs0.copy_like(IC_ins0)
+        IC_outs0.P = IC.P = self.P
+        IC_ins0.phase = IC_outs0.phase = 'g'
+        IC.simulate()
+
+        hx = self.hx
+        inf_hx = self.inf_hx
+        inf_hx_in, inf_hx_out = inf_hx.ins[0], inf_hx.outs[0]
+        inf_pre_hx, eff_pre_hx = hx.ins
+        inf_after_hx, eff_after_hx = hx.outs
+        inf_pre_hx.copy_like(self.ins[0])
+        eff_pre_hx.copy_like(self.outs[0])
+
+        if self.internal_heat_exchanging:
+            hx.simulate()
+        else:
+            hx.empty()
+            inf_after_hx.copy_like(inf_pre_hx)
+            eff_after_hx.copy_like(eff_pre_hx)
+
+        if self.inf_T is not None:
+            # Preheat oil and hydrogen (fresh + recycled, already at the
+            # compressor's outlet pressure) SEPARATELY, both only to `inf_T`
+            # -- the remaining rise from `inf_T` to `T` is treated as coming
+            # from the reaction's own exotherm (uncosted); see the class
+            # docstring for why `inf_T` is a caller-supplied literature value
+            # rather than something computed from thermodynamic data. Two
+            # separate exchangers (matching the old, pre-refactor model's
+            # topology) rather than one combined mixed-stream exchanger,
+            # since mixing oil and H2 before heating produces a real,
+            # non-additive lower total duty than heating them apart --
+            # confirmed via diagnostics -- and both need to independently
+            # participate in whole-plant heat-exchanger-network integration.
+            inf_hx_in.copy_like(inf_after_hx)
+            inf_hx_out.copy_flow(inf_hx_in)
+            inf_hx_out.T = self.inf_T
+            inf_hx_out.P = self.P
+            inf_hx.simulate_as_auxiliary_exchanger(ins=inf_hx.ins, outs=inf_hx.outs)
+
+            h2_hx = self.inf_hx_H2
+            h2_hx_in, h2_hx_out = h2_hx.ins[0], h2_hx.outs[0]
+            h2_hx_in.copy_like(IC_outs0)
+            h2_hx_out.copy_flow(h2_hx_in)
+            # `copy_flow` doesn't copy phase; simulate_as_auxiliary_exchanger's
+            # outs-given/duty=None path computes duty from outlet.Hnet directly
+            # without re-resolving VLE, so a stale (default liquid) phase on a
+            # 100% H2 stream would badly corrupt this exchanger's duty.
+            h2_hx_out.phase = h2_hx_in.phase
+            h2_hx_out.T = self.inf_T
+            h2_hx_out.P = self.P
+            h2_hx.simulate_as_auxiliary_exchanger(ins=h2_hx.ins, outs=h2_hx.outs)
+        else:
+            inf_hx_in.copy_like(inf_after_hx)
+            inf_hx_out.copy_flow(inf_hx_in)
+            inf_hx_out.T = self.T
+            inf_hx_out.P = self.P
+            inf_hx.simulate_as_auxiliary_exchanger(ins=inf_hx.ins, outs=inf_hx.outs)
+            self.inf_hx_H2.empty() # unused for this path (e.g. saf's own inf_T=None use)
+
+        if self.dynamic_V_wf:
+            # Old, pre-refactor model discounted working volume for H2 gas's
+            # disproportionate volume vs. liquid oil rather than using a flat
+            # constant; confirmed via diagnostics to reproduce the old
+            # model's installed cost almost exactly when combined with
+            # itemized (non-decorated) reactor costing.
+            V_H2 = H2.F_vol/self.hydrogen_ratio*101325/self.P
+            V_oil = self.ins[0].F_vol
+            self.V_wf = 0.4*V_oil/(V_oil + V_H2)
+
+        Reactor._design(self)
+
+    def _cost(self):
+        Cost = self.baseline_purchase_costs
+        Cost.clear()
+
+        use_decorated_cost = self.use_decorated_cost
+        include_PSA = self.include_PSA
+        self._decorated_cost()
+
+        if use_decorated_cost == 'Hydrocracker':
+            Cost.pop('Hydrotreater')
+        elif use_decorated_cost == 'Hydrotreater':
+            Cost.pop('Hydrocracker')
+        else:
+            Cost.pop('Hydrocracker')
+            Cost.pop('Hydrotreater')
+            Reactor._cost(self)
+
+        if not include_PSA: Cost.pop('PSA')
+
     def _normalize_composition(self, dct):
         total = sum(dct.values())
-        if total <=0: raise ValueError(f'Sum of total yields/composition should be positive, not {total}.')
-        return {k:v/total for k, v in dct.items()}
-    
+        if total <= 0: raise ValueError(f'Sum of total yields/composition should be positive, not {total}.')
+        return {k: v/total for k, v in dct.items()}
+
+    def _normalize_yields(self):
+        gas = self._gas_yield
+        oil = self._oil_yield
+        gas_oil = gas + oil
+        aq = 0
+        if gas_oil > 1:
+            gas /= gas_oil
+            oil /= gas_oil
+        else:
+            aq = 1 - gas_oil
+        self._gas_yield = gas
+        self._oil_yield = oil
+        self._aq_yield = aq
+
+    @property
+    def gas_yield(self):
+        '''[float] Mass ratio of fuel gas to the sum of influent oil and reacted H2.
+        Setting this triggers renormalization: if gas_yield + oil_yield > 1, both are
+        rescaled proportionally; otherwise aq_yield absorbs the remainder.'''
+        return self._gas_yield
+    @gas_yield.setter
+    def gas_yield(self, gas):
+        self._gas_yield = gas
+        if hasattr(self, '_oil_yield'):
+            self._normalize_yields()
+
+    @property
+    def oil_yield(self):
+        '''[float] Mass ratio of treated oil to the sum of influent oil and reacted H2.
+        Setting this triggers renormalization: if gas_yield + oil_yield > 1, both are
+        rescaled proportionally; otherwise aq_yield absorbs the remainder.'''
+        return self._oil_yield
+    @oil_yield.setter
+    def oil_yield(self, oil):
+        self._oil_yield = oil
+        if hasattr(self, '_gas_yield'):
+            self._normalize_yields()
+
+    @property
+    def aq_yield(self):
+        '''[float] Mass ratio of aqueous phase to the sum of influent oil and reacted H2.
+        Read-only; derived as 1 - gas_yield - oil_yield (or 0 if their sum > 1).'''
+        return self._aq_yield
+
     @property
     def gas_composition(self):
         return self._gas_composition
     @gas_composition.setter
     def gas_composition(self, comp_dct):
         self._gas_composition = self._normalize_composition(comp_dct)
-        
+
     @property
     def oil_composition(self):
         return self._oil_composition
     @oil_composition.setter
     def oil_composition(self, comp_dct):
         self._oil_composition = self._normalize_composition(comp_dct)
-        
+
     @property
-    def HC_composition(self):
-        '''Composition of gas and oil products, normalized to 100%.'''
+    def aqueous_composition(self):
+        return self._aqueous_composition
+    @aqueous_composition.setter
+    def aqueous_composition(self, comp_dct):
+        self._aqueous_composition = self._normalize_composition(comp_dct)
+
+    @property
+    def eff_composition(self):
+        '''[dict] Composition of the blended effluent, normalized to 100% sum.'''
         gas_composition = self.gas_composition
-        oil_composition = self.oil_composition       
+        oil_composition = self.oil_composition
+        aqueous_composition = self.aqueous_composition
         oil_yield = self.oil_yield
-        gas_yield = 1 - oil_yield
-        HC_composition = {k:v*gas_yield for k, v in gas_composition.items()}
-        HC_composition.update({k:v*oil_yield for k, v in oil_composition.items()})
-        return self._normalize_composition(HC_composition)
+        gas_yield = self.gas_yield
+        aq_yield = self.aq_yield
+        eff_composition = {k: v*gas_yield for k, v in gas_composition.items()}
+        eff_composition.update({k: v*oil_yield for k, v in oil_composition.items()})
+        eff_composition.update({k: v*aq_yield for k, v in aqueous_composition.items()})
+        return self._normalize_composition(eff_composition)
 
     @property
-    def hydrocarbon_C(self):   
-        return sum(self.outs[0].imass[self.HC_composition]*
-                   [cmp.i_C for cmp in self.components[self.HC_composition]])
-
-    def _design(self):
-        IC = self.compressor
-        IC_ins0, IC_outs0 = IC.ins[0], IC.outs[0]
-        IC_ins0.copy_like(self.ins[1])
-        IC_outs0.copy_like(self.ins[1])
-        IC_outs0.P = IC.P = self.hydrogen_P
-        IC_ins0.phase = IC_outs0.phase = 'g'
-        IC.simulate()
-        
-        hx_H2 = self.heat_exchanger_H2
-        hx_H2_ins0, hx_H2_outs0 = hx_H2.ins[0], hx_H2.outs[0]
-        hx_H2_ins0.copy_like(self.ins[1])
-        hx_H2_outs0.copy_like(hx_H2_ins0)
-        hx_H2_ins0.phase = hx_H2_outs0.phase = 'g'
-        self._mixed_in.mix_from(self.ins)
-        if not self.HCin_T: self.HCin_T = self._mixed_in.T
-        hx_H2_outs0.T = self.HCin_T
-        hx_H2_ins0.P = hx_H2_outs0.P = IC_outs0.P
-        hx_H2.simulate_as_auxiliary_exchanger(ins=hx_H2.ins, outs=hx_H2.outs)
-
-        hx_oil = self.heat_exchanger_oil
-        hx_oil_ins0, hx_oil_outs0 = hx_oil.ins[0], hx_oil.outs[0]
-        hx_oil_ins0.copy_like(self.ins[0])
-        hx_oil_outs0.copy_like(hx_oil_ins0)
-        hx_oil_outs0.T = self.HCin_T
-        hx_oil_ins0.P = hx_oil_outs0.P = self.ins[0].P
-        hx_oil.simulate_as_auxiliary_exchanger(ins=hx_oil.ins, outs=hx_oil.outs)
-        
-        self.P = min(IC_outs0.P, self.ins[0].P)
-        
-        V_H2 = self.ins[1].F_vol/self.hydrogen_excess*101325/self.hydrogen_P
-        # just account for reacted H2
-        V_biocrude = self.ins[0].F_vol
-        self.V_wf = self.void_fraciton*V_biocrude/(V_biocrude + V_H2)
-        Reactor._design(self)
-
-        
-# %%
-
-# =============================================================================
-# HT
-# =============================================================================
-
-@cost(basis='Hydrogen_PSA', ID='PSA', units='mmscfd',
-      cost=1750000, S=10,
-      CE=CEPCI_by_year[2004], n=0.8, BM=2.47)
-class Hydrotreating(Reactor):
-    '''
-    Biocrude mixed with H2 are hydrotreated at elevated temperature (405°C)
-    and pressure to produce upgraded biooil. Co-product includes fuel gas.
-    A pressure swing adsorption (PSA) process can be optionally included
-    for H2 recovery.
-    
-    Parameters
-    ----------
-    ins : Iterable(stream)
-        biocrude, hydrogen, catalyst_in.
-    outs : Iterable(stream)
-        ht_out, catalyst_out = self.outs.
-    WHSV: float
-        Weight Hourly Space velocity, [kg feed/hr/kg catalyst].
-    catalyst_lifetime: float
-        HT catalyst lifetime, [hr].
-    catalyst_ID : str
-        ID of the catalyst.
-    hydrogen_P: float
-        Hydrogen pressure, [Pa].
-    hydrogen_rxned_to_inf_oil: float
-        Reacted H2 to influent oil mass ratio.
-    hydrogen_excess: float
-        Actual hydrogen amount = hydrogen_rxned_to_biocrude*hydrogen_excess
-    hydrocarbon_ratio: float
-        Mass ratio of produced hydrocarbon to the sum of biocrude and reacted H2.
-    HTin_T: float
-        HT influent temperature, [K].
-    HTrxn_T: float
-        HT effluent (after reaction) temperature, [K].
-    HT_composition: dict
-        HT effluent composition.
-    CAPEX_factor: float
-        Factor used to adjust CAPEX.
-    include_PSA : bool
-        Whether to include pressure swing adsorption for H2 recovery.
-        
-    References
-    ----------
-    [1] Jones, S. B.; Zhu, Y.; Anderson, D. B.; Hallen, R. T.; Elliott, D. C.; 
-        Schmidt, A. J.; Albrecht, K. O.; Hart, T. R.; Butcher, M. G.; Drennan, C.; 
-        Snowden-Swan, L. J.; Davis, R.; Kinchin, C. 
-        Process Design and Economics for the Conversion of Algal Biomass to
-        Hydrocarbons: Whole Algae Hydrothermal Liquefaction and Upgrading;
-        PNNL--23227, 1126336; 2014; https://doi.org/10.2172/1126336.
-    [2] Towler, G.; Sinnott, R. Chapter 14 - Design of Pressure Vessels.
-        In Chemical Engineering Design (Second Edition); Towler, G., Sinnott, R.,
-        Eds.; Butterworth-Heinemann: Boston, 2013; pp 563–629.
-        https://doi.org/10.1016/B978-0-08-096659-5.00014-6.
-    '''
-    _N_ins = 3
-    _N_outs = 2
-    auxiliary_unit_names=('compressor','heat_exchanger',)
-    
-    _F_BM_default = {**Reactor._F_BM_default,
-                     'Heat exchanger': 3.17,
-                     'Compressor': 1.1}
-    
-    _units = {'Hydrogen': 'mmscfd',
-              'Hydrogen_PSA': 'mmscfd'}
-    
-    def __init__(self, ID='', ins=None, outs=(), thermo=None,
-                 init_with='Stream',
-                 WHSV=0.625, # wt./hr per wt. catalyst [1]
-                 catalyst_lifetime=2*7920, # 2 years [1]
-                 catalyst_ID='HT_catalyst',
-                 hydrogen_P=1530*6894.76,
-                 hydrogen_rxned_to_inf_oil=0.046,
-                 hydrogen_excess=3,
-                 # spreadsheet HT calculation
-                 hydrocarbon_ratio=0.875, # 87.5 wt% of biocrude and reacted H2 [1]
-                 # Tin = 174 C (345 F) based on Jones PNNL report
-                 # however, the reaction releases heat and increase the temperature of effluent to 402 C (755.5 F)
-                 HTin_T=174+273.15,
-                 HTrxn_T=402+273.15, # [1]
-                 HT_composition={'CH4':0.02280, 'C2H6':0.02923,
-                                 'C3H8':0.01650, 'C4H10':0.00870,
-                                 'TWOMBUTAN':0.00408, 'NPENTAN':0.00678,
-                                 'TWOMPENTA':0.00408, 'HEXANE':0.00401,
-                                 'TWOMHEXAN':0.00408, 'HEPTANE':0.00401,
-                                 'CC6METH':0.01020, 'PIPERDIN':0.00408,
-                                 'TOLUENE':0.01013, 'THREEMHEPTA':0.01020,
-                                 'OCTANE':0.01013, 'ETHCYC6':0.00408,
-                                 'ETHYLBEN':0.02040, 'OXYLENE':0.01020,
-                                 'C9H20':0.00408, 'PROCYC6':0.00408,
-                                 'C3BENZ':0.01020, 'FOURMONAN':0,
-                                 'C10H22':0.00240, 'C4BENZ':0.01223,
-                                 # C10H22 was originally 0.00203, but it is not
-                                 # good for distillation column, the excess amount
-                                 # is substracted from HEXANE, HEPTANE, TOLUENE,
-                                 # OCTANE, and C9H20, which were originally 0.00408,
-                                 # 0.00408, 0.01020, 0.01020, and 0.00408
-                                 'C11H24':0.02040, 'C10H12':0.02040,
-                                 'C12H26':0.02040, 'OTTFNA':0.01020,
-                                 'C6BENZ':0.02040, 'OTTFSN':0.02040,
-                                 'C7BENZ':0.02040, 'C8BENZ':0.02040,
-                                 'C10H16O4':0.01837, 'C15H32':0.06120,
-                                 'C16H34':0.18360, 'C17H36':0.08160, 
-                                 'C18H38':0.04080, 'C19H40':0.04080,
-                                 'C20H42':0.10200, 'C21H44':0.04080,
-                                 'TRICOSANE':0.04080, 'C24H38O4':0.00817,
-                                 'C26H42O4':0.01020, 'C30H62':0.00203}, # [1]
-                 # spreadsheet HT calculation
-                 # will not be a variable in uncertainty/sensitivity analysis
-                 P=None, tau=0.5, void_fraciton=0.4, # [2]
-                 length_to_diameter=2, diameter=None,
-                 N=None, V=None, auxiliary=False,
-                 mixing_intensity=None, kW_per_m3=0,
-                 wall_thickness_factor=1,
-                 vessel_material='Stainless steel 316',
-                 vessel_type='Vertical',
-                 CAPEX_factor=1,
-                 include_PSA=False,
-                 PSA_pre=717.4*6894.76,
-                 PSA_efficiency=0.9,):
-        
-        SanUnit.__init__(self, ID, ins, outs, thermo, init_with)
-        self.WHSV = WHSV
-        self.catalyst_lifetime = catalyst_lifetime
-        self.catalyst_ID = catalyst_ID
-        self.hydrogen_P = hydrogen_P
-        self.hydrogen_rxned_to_inf_oil = hydrogen_rxned_to_inf_oil
-        self.hydrogen_excess = hydrogen_excess
-        self.hydrocarbon_ratio = hydrocarbon_ratio
-        self.HTin_T = HTin_T
-        self.HTrxn_T = HTrxn_T
-        self.HT_composition = HT_composition
-        IC_in = Stream(f'{ID}_IC_in')
-        IC_out = Stream(f'{ID}_IC_out')
-        self.compressor = IsothermalCompressor(ID=f'.{ID}_IC', ins=IC_in,
-                                               outs=IC_out, P=None)
-        hx_H2_in = Stream(f'{ID}_hx_H2_in')
-        hx_H2_out = Stream(f'{ID}_hx_H2_out')
-        self.heat_exchanger_H2 = HXutility(ID=f'.{ID}_hx_H2', ins=hx_H2_in, outs=hx_H2_out)
-        hx_oil_in = Stream(f'{ID}_hx_oil_in')
-        hx_oil_out = Stream(f'{ID}_hx_oil_out')
-        self.heat_exchanger_oil = HXutility(ID=f'.{ID}_hx_oil', ins=hx_oil_in, outs=hx_oil_out)
-        self.P = P
-        self.tau = tau
-        self.void_fraciton = void_fraciton
-        self.length_to_diameter = length_to_diameter
-        self.diameter = diameter
-        self.N = N
-        self.V = V
-        self.auxiliary = auxiliary
-        self.mixing_intensity = mixing_intensity
-        self.kW_per_m3 = kW_per_m3
-        self.wall_thickness_factor = wall_thickness_factor
-        self.vessel_material = vessel_material
-        self.vessel_type = vessel_type
-        self.CAPEX_factor = CAPEX_factor
-        self.include_PSA = include_PSA
-        self.PSA_pre = PSA_pre
-        self.PSA_efficiency = PSA_efficiency
-        
-    def _run(self):
-        
-        biocrude, hydrogen, catalyst_in = self.ins
-        ht_out, catalyst_out = self.outs
-        
-        self.HTL = self.ins[0]._source.ins[0]._source
-        
-        HT_composition = self.HT_composition
-        if self.HTL.biocrude_N == 0:
-            remove = HT_composition['PIPERDIN']
-            for chemical in self.HT_composition.keys():  
-                HT_composition[chemical] /= (1-remove)
-            HT_composition['PIPERDIN'] = 0
-        
-        catalyst_in.imass[self.catalyst_ID] = biocrude.F_mass/self.WHSV/self.catalyst_lifetime
-        catalyst_in.phase = 's'
-        catalyst_out.copy_like(catalyst_in)
-        # catalysts amount is quite low compared to the main stream, therefore do not consider
-        # heating/cooling of catalysts
-        
-        hydrogen_excess = self.hydrogen_excess
-        H2_rxned =  biocrude.imass['Biocrude']*self.hydrogen_rxned_to_inf_oil
-        recovered_frac =  (hydrogen_excess - 1)*self.PSA_efficiency*float(self.include_PSA)
-        hydrogen.imass['H2'] = H2_rxned*(hydrogen_excess - recovered_frac)
-        hydrogen.phase = 'g'
-
-        hydrocarbon_mass = biocrude.imass['Biocrude']*\
-                           (1 + self.hydrogen_rxned_to_inf_oil)*\
-                           self.hydrocarbon_ratio
-                           
-        ht_out.phase = 'g'
-                           
-        for name, ratio in self.HT_composition.items():
-            ht_out.imass[name] = hydrocarbon_mass*ratio
-            
-        ht_out.imass['H2'] = H2_rxned*(self.hydrogen_excess - recovered_frac - 1)
-        
-        ht_out.imass['H2O'] = biocrude.F_mass + hydrogen.F_mass -\
-                              hydrocarbon_mass - ht_out.imass['H2']
-        # use water to represent HT aqueous phase,
-        # C and N can be calculated base on MB closure.
-        
-        ht_out.P = biocrude.P
-        
-        ht_out.T = self.HTrxn_T
-        
-        ht_out.vle(T=ht_out.T, P=ht_out.P)
-        
-        if self.HTaqueous_C < -0.1*self.HTL.WWTP.sludge_C:
-            raise Exception('carbon mass balance is out of +/- 10% for the whole system')
-        # allow +/- 10% out of mass balance
-        # should be no C in the aqueous phase, the calculation here is just for MB
-
-        if self.HTaqueous_N < -0.1*self.HTL.WWTP.sludge_N:
-            Warning('nitrogen mass balance is out of +/- 10% for the whole system')
-        # allow +/- 10% out of mass balance
-
-        # possibility exist that more carbon is in biooil and gas than in
-        # biocrude because we use the biooil/gas compositions to calculate
-        # carbon. In this case, the C in HT aqueous phase will be negative.
-        # It's OK if the mass balance is within +/- 10% of total carbon in 
-        # sludge. Otherwise, an exception will be raised.
-        
-    @property
-    def hydrocarbon_C(self):   
-        return sum(self.outs[0].imass[self.HT_composition]*
-                   [cmp.i_C for cmp in self.components[self.HT_composition]])
-
-    @property
-    def hydrocarbon_N(self):
-        return sum(self.outs[0].imass[self.HT_composition]*
-                   [cmp.i_N for cmp in self.components[self.HT_composition]])
-
-    @property
-    def HTaqueous_C(self):
-        return self.HTL.biocrude_C - self.hydrocarbon_C
-    # should be no C in the aqueous phase, the calculation here is just for MB
-
-    @property
-    def HTaqueous_N(self):
-        return self.HTL.biocrude_N - self.hydrocarbon_N
-    
-    @property
-    def PSA_efficiency (self):
-        return self._PSA_efficiency 
+    def PSA_efficiency(self):
+        '''[float] H2 recovery efficiency of the PSA unit, forced to 0 if `include_PSA` is False.'''
+        if self.include_PSA: return self._PSA_efficiency
+        return 0
     @PSA_efficiency.setter
     def PSA_efficiency(self, i):
-        if i > 1: raise Exception('PSA efficiency cannot be larger than 1.')
-        self._PSA_efficiency  = i
-
-    def _design(self):
-        
-        IC = self.compressor
-        IC_ins0, IC_outs0 = IC.ins[0], IC.outs[0]
-        IC_ins0.copy_like(self.ins[1])
-        IC_outs0.copy_like(self.ins[1])
-        IC_outs0.P = IC.P = self.hydrogen_P
-        IC_ins0.phase = IC_outs0.phase = 'g'
-        IC.simulate()
-
-        hx_H2 = self.heat_exchanger_H2
-        hx_H2_ins0, hx_H2_outs0 = hx_H2.ins[0], hx_H2.outs[0]
-        hx_H2_ins0.copy_like(self.ins[1])
-        hx_H2_outs0.copy_like(hx_H2_ins0)
-        hx_H2_ins0.phase = hx_H2_outs0.phase = 'g'
-        hx_H2_outs0.T = self.HTin_T
-        hx_H2_ins0.P = hx_H2_outs0.P = IC_outs0.P
-        hx_H2.simulate_as_auxiliary_exchanger(ins=hx_H2.ins, outs=hx_H2.outs)
-        
-        hx_oil = self.heat_exchanger_oil
-        hx_oil_ins0, hx_oil_outs0 = hx_oil.ins[0], hx_oil.outs[0]
-        hx_oil_ins0.copy_like(self.ins[0])
-        hx_oil_outs0.copy_like(hx_oil_ins0)
-        hx_oil_outs0.T = self.HTin_T
-        hx_oil_ins0.P = hx_oil_outs0.P = self.ins[0].P
-        hx_oil.simulate_as_auxiliary_exchanger(ins=hx_oil.ins, outs=hx_oil.outs)
-        
-        self.P = min(IC_outs0.P, self.ins[0].P)
-        
-        V_H2 = self.ins[1].F_vol/self.hydrogen_excess*101325/self.hydrogen_P
-        # just account for reacted H2
-        V_biocrude = self.ins[0].F_vol
-        self.V_wf = self.void_fraciton*V_biocrude/(V_biocrude + V_H2)
-        Reactor._design(self)
-        
-        Design = self.design_results
-        factor = float(self.include_PSA)
-        Design['Hydrogen_PSA'] = self.ins[1].F_vol*_m3perh_to_mmscfd*101325/self.PSA_pre*factor
-        Design['PSA'] = 0.5*Design['Weight']*Design['Number of reactors']*factor # assume stainless steel
-        # based on [1], page 54, the purchase price of PSA to the purchase price of
-        # HT reactor (excluding vessels and columns) is around 0.5,
-        # therefore, assume the weight of PSA is 0.5*single HT weight*number of HT reactors
-        self.construction[0].quantity += Design['PSA']*_lb_to_kg*factor
-        
-    
-    def _cost(self):
-        Reactor._cost(self)
-        
-        purchase_costs = self.baseline_purchase_costs
-        CAPEX_factor = self.CAPEX_factor
-        if self.include_PSA: self._decorated_cost()
-        else: purchase_costs['Hydrogen_PSA'] = 0
-        
-        for item in purchase_costs.keys():
-            purchase_costs[item] *= CAPEX_factor
+        if i > 1: raise ValueError('PSA_efficiency cannot be larger than 1.')
+        self._PSA_efficiency = i

--- a/qsdsan/unit_operations/static/_hydrothermal.py
+++ b/qsdsan/unit_operations/static/_hydrothermal.py
@@ -19,12 +19,13 @@ from biosteam.units.decorators import cost
 from qsdsan import SanUnit, Stream, CEPCI_by_year
 from qsdsan.utils import auom
 from ._reactor import Reactor
-from ..bst import HXutility
+from ..bst import HXutility, HXprocess
 from ..dynamic import Pump
 
 __all__ = (
     'CatalyticHydrothermalGasification',
     'HydrothermalLiquefaction',
+    'KnockOutDrum',
     )
 
 _lb_to_kg = auom('lb').conversion_factor('kg')
@@ -167,9 +168,9 @@ class CatalyticHydrothermalGasification(Reactor):
         catalyst_out.copy_like(catalyst_in)
         # catalysts amount is quite low compared to the main stream, therefore do not consider
         # heating/cooling of catalysts
-        
-        # chg_out.phase='g'
-        
+
+        chg_out.phase = 'g'
+
         cmps = self.components
         gas_C_ratio = 0
         for name, ratio in self.gas_composition.items():
@@ -182,11 +183,11 @@ class CatalyticHydrothermalGasification(Reactor):
                 
         chg_out.imass['H2O'] = chg_in.F_mass - gas_mass
         # all C, N, and P are accounted in H2O here, but will be calculated as properties.
-        
+
         chg_out.T = self.cool_temp
         chg_out.P = self.pump_pressure
 
-        # chg_out.vle(T=chg_out.T, P=chg_out.P)
+        chg_out.vle(T=chg_out.T, P=chg_out.P)
 
     @property
     def CHGout_C(self):
@@ -263,26 +264,45 @@ class CatalyticHydrothermalGasification(Reactor):
 
 class KnockOutDrum(Reactor):
     '''
-    Knockout drum is an auxiliary unit for :class:`HydrothermalLiquefaction`.
-    
+    Knockout drum is an auxiliary unit for :class:`HydrothermalLiquefaction`,
+    used when its cost is calculated using generic pressure vessel algorithms
+    (i.e., `HydrothermalLiquefaction`'s `use_decorated_cost` is False).
+
+    Parameters
+    ----------
+    drum_cost_factor : float
+        Cost multiplier applied to the vessel's own baseline purchase cost
+        (on top of `vessel_material`'s material factor, which biosteam's
+        `PressureVessel` machinery already applies automatically), to match
+        the pre-refactor sludge model's own `drum_steel_cost_factor`.
+        Defaults to 1.5 -- see [1], page 54: fully scaling the reference
+        report's factor from 2000 to 100 tons/day would need ~3, but that is
+        too high, so 1.5 is used instead.
+
+    See Also
+    --------
+    :class:`HydrothermalLiquefaction`
+
+    :class:`Reactor`
+
+    :class:`biosteam.units.design_tools.PressureVessel`
+
+    `saf systems <https://github.com/QSD-Group/EXPOsan/tree/main/exposan/saf>`_
+
     References
     ----------
     [1] Knorr, D.; Lukas, J.; Schoen, P. Production of Advanced Biofuels via
         Liquefaction - Hydrothermal Liquefaction Reactor Design: April 5, 2013;
         NREL/SR-5100-60462, 1111191; 2013; p NREL/SR-5100-60462, 1111191.
         https://doi.org/10.2172/1111191.
-        
-    See Also
-    --------
-    :class:`qsdsan.unit_operations.HydrothermalLiquefaction`
     '''
     _N_ins = 3
     _N_outs = 2
     _ins_size_is_fixed = False
     _outs_size_is_fixed = False
-    
+
     def __init__(self, ID='', ins=None, outs=(), thermo=None,
-                 init_with='Stream',
+                 init_with='Stream', include_construction=False,
                  P=3049.7*6894.76, tau=0, V_wf=0,
                  length_to_diameter=2, diameter=None,
                  N=4, V=None,
@@ -291,13 +311,10 @@ class KnockOutDrum(Reactor):
                  wall_thickness_factor=1,
                  vessel_material='Stainless steel 316',
                  vessel_type='Vertical',
-                 drum_steel_cost_factor=1.5):
-        # drum_steel_cost_factor: so the cost matches [1]
-        # when do comparison, if fully consider scaling factor (2000 tons/day to 100 tons/day),
-        # drum_steel_cost_factor should be around 3
-        # but that is too high, we use 1.5 instead.
-        
-        SanUnit.__init__(self, ID, ins, outs, thermo, init_with)
+                 drum_cost_factor=1.5,
+                 ):
+        SanUnit.__init__(self, ID, ins, outs, thermo, init_with,
+                          include_construction=include_construction)
         self.P = P
         self.tau = tau
         self.V_wf = V_wf
@@ -311,204 +328,191 @@ class KnockOutDrum(Reactor):
         self.wall_thickness_factor = wall_thickness_factor
         self.vessel_material = vessel_material
         self.vessel_type = vessel_type
-        self.drum_steel_cost_factor = drum_steel_cost_factor
-    
+        self.drum_cost_factor = drum_cost_factor
+
     def _run(self):
         pass
-    
+
     def _cost(self):
+        # `self.F_M` is NOT usable for this: `vessel_material`'s setter
+        # (biosteam.units.design_tools.pressure_vessel.PressureVessel)
+        # unconditionally overwrites F_M['Vertical/Horizontal pressure
+        # vessel'] with the plain per-material factor as a side effect of
+        # being assigned. Applying as a multiplier on baseline_purchase_costs instead.
         Reactor._cost(self)
-        
         purchase_costs = self.baseline_purchase_costs
-        purchase_costs['Vertical pressure vessel'] *= self.drum_steel_cost_factor
+        purchase_costs[f'{self.vessel_type} pressure vessel'] *= self.drum_cost_factor
 
 # =============================================================================
 # HTL
 # =============================================================================
 
-# separator
-@cost(basis='Treatment capacity', ID='Solids filter oil/water separator', units='lb/h',
-      cost=3945523, S=1219765,
+@cost(basis='Wet mass flowrate', ID='HTL system', units='lb/hr',
+      cost=37486757, S=574476,
+      CE=CEPCI_by_year[2011], n=0.77, BM=2.1)
+@cost(basis='Wet mass flowrate', ID='Solids filter oil/water separator', units='lb/hr',
+      cost=3945523, S=574476,
       CE=CEPCI_by_year[2011], n=0.68, BM=1.9)
+@cost(basis='Wet mass flowrate', ID='Hot oil system', units='lb/hr',
+      cost=4670532, S=574476,
+      CE=CEPCI_by_year[2011], n=0.6, BM=1.4)
 class HydrothermalLiquefaction(Reactor):
     '''
-    HTL converts dewatered sludge to biocrude, aqueous, off-gas, and hydrochar
-    under elevated temperature (350°C) and pressure. The products percentage
-    (wt%) can be evaluated using revised MCA model (Li et al., 2017,
-    Leow et al., 2018) with known sludge composition (protein%, lipid%,
-    and carbohydrate%, all afdw%).
-                                                      
-    Notice that for HTL we just calculate each phases' total mass (except gas)
-    and calculate C, N, and P amount in each phase as properties. We don't
-    specify components for oil/char since we want to use MCA model to calculate
-    C and N amount and it is not necessary to calculate every possible
-    components since they will be treated in HT/AcidEx anyway. We also don't
-    specify components for aqueous since we want to calculate aqueous C, N, and
-    P based on mass balance closure. But later for CHG, HT, and HC, we specify
-    each components (except aqueous phase) for the application of flash,
-    distillation column, and CHP units.
-    
+    HTL converts feedstock to gas, aqueous, biocrude, and (hydro)char under
+    elevated temperature and pressure. Product yields and compositions are
+    directly specified via `dw_yields` and the four `*_composition` dicts
+    (no feedstock-composition correlation is modeled here — subclass this
+    unit to add one, e.g. a sludge-biochemical-composition correlation).
+
     Parameters
     ----------
     ins : Iterable(stream)
-        dewatered_sludge.
+        Feedstock into HTL.
     outs : Iterable(stream)
-        hydrochar, HTLaqueous, biocrude, offgas.
-    lipid_2_biocrude: float
-        Lipid to biocrude factor.
-    protein_2_biocrude: float
-        Protein to biocrude factor.
-    carbo_2_biocrude: float
-        Carbohydrate to biocrude factor.
-    protein_2_gas: float
-        Protein to gas factor.
-    carbo_2_gas: float
-        Carbohydrate to gas factor.
-    biocrude_C_slope: float
-        Biocrude carbon content slope.
-    biocrude_C_intercept: float
-        Biocrude carbon content intercept.
-    biocrude_N_slope: float
-        Biocrude nitrogen content slope.
-    biocrude_H_slope: float
-        Biocrude hydrogen content slope.
-    biocrude_H_intercept: float
-        Biocrude hydrogen content intercept.
-    HTLaqueous_C_slope: float
-        HTLaqueous carbon content slope.
-    TOC_TC: float   
-        HTL TOC/TC.
-    hydrochar_C_slope: float
-        Hydrochar carbon content slope.
-    hydrochar_H_slope: float
-        Hydrochar hydrogen content slope.
-    biocrude_moisture_content: float
-        Biocrude moisture content.
-    hydrochar_P_recovery_ratio: float
-        Hydrochar phosphorus to total phosphorus ratio.
-    gas_composition: dict
-        HTL offgas compositions.
-    hydrochar_pre: float
-        Hydrochar pressure, [Pa].
-    HTLaqueous_pre: float
-        HTL aqueous phase pressure, [Pa].
-    biocrude_pre: float
-        Biocrude pressure, [Pa].
-    offgas_pre: float
-        Offgas pressure, [Pa].
-    eff_T: float
-        HTL effluent temperature, [K].
-    CAPEX_factor: float
-        Factor used to adjust CAPEX.
-    HTL_steel_cost_factor: float
-        Factor used to adjust the cost of stainless steel.
-    mositure_adjustment_exist_in_the_system: bool
-        If a moisture adjustment unit exists, set to true.
-        
+        Gas, aqueous, biocrude, char.
+    T : float
+        Temperature of the HTL reaction, [K].
+    P : float
+        Pressure when the reaction is at temperature, [Pa].
+    dw_yields : dict
+        Dry weight percentage yields of the four products (gas, aqueous, biocrude, char),
+        normalized to 100% sum. Keys must be 'gas', 'aqueous', 'biocrude', and 'char'.
+    gas_composition : dict
+        Composition of the gaseous products including water, normalized to 100% sum.
+    aqueous_composition : dict
+        Composition of the aqueous products excluding water, normalized to 100% sum.
+        Water not allocated to other products all goes to aqueous.
+    biocrude_composition : dict
+        Composition of the biocrude products including water, normalized to 100% sum.
+    char_composition : dict
+        Composition of the char products including water, normalized to 100% sum.
+    internal_heat_exchanging : bool
+        If True, use the product to preheat the feedstock.
+    eff_T : float
+        HTL effluent temperature, [K]; if provided, an additional HX controls
+        effluent temperature.
+    eff_P : float
+        HTL effluent pressure, [Pa].
+    use_decorated_cost : bool
+        If True, use cost scaled per [1]; otherwise use generic `Reactor`
+        (`PressureVessel`) costing.
+    F_M : dict
+        Material factors used to adjust cost (only used when `use_decorated_cost` is False).
+
+    Examples
+    --------
+    >>> from qsdsan import Components, WasteStream, set_thermo
+    >>> from qsdsan.unit_operations import HydrothermalLiquefaction
+    >>> cmps = Components.load_default()
+    >>> set_thermo(cmps)
+    >>> feed = WasteStream('htl_feed', S_F=200, Water=800, units='kg/hr')
+    >>> HTL = HydrothermalLiquefaction(
+    ...     'HTL', ins=feed, outs=('gas', 'aq', 'crude', 'char'),
+    ...     dw_yields={'gas': 0.05, 'aqueous': 0.15, 'biocrude': 0.4, 'char': 0.4},
+    ...     gas_composition={'S_CH4': 0.5, 'S_H2': 0.5},
+    ...     aqueous_composition={'Water': 1},
+    ...     biocrude_composition={'S_F': 0.5, 'Water': 0.5},
+    ...     char_composition={'Water': 1},
+    ...     T=280+273.15,
+    ...     internal_heat_exchanging=False,
+    ...     )
+    >>> HTL.simulate()
+    >>> gas, aq, crude, char = HTL.outs
+    >>> round(crude.imass['S_F'], 2)  # kg/hr
+    40.0
+    >>> sorted(type(u).__name__ for u in HTL.auxiliary_units)
+    ['HXprocess', 'HXutility', 'HXutility']
+
+    See Also
+    --------
+    :class:`KnockOutDrum`
+
+    :class:`Reactor`
+
+    :class:`biosteam.units.design_tools.PressureVessel`
+
+    `saf systems <https://github.com/QSD-Group/EXPOsan/tree/main/exposan/saf>`_
+
     References
     ----------
-    [1] Leow, S.; Witter, J. R.; Vardon, D. R.; Sharma, B. K.;
-        Guest, J. S.; Strathmann, T. J. Prediction of Microalgae Hydrothermal
-        Liquefaction Products from Feedstock Biochemical Composition.
-        Green Chem. 2015, 17 (6), 3584–3599. https://doi.org/10.1039/C5GC00574D.
-    [2] Li, Y.; Leow, S.; Fedders, A. C.; Sharma, B. K.; Guest, J. S.;
-        Strathmann, T. J. Quantitative Multiphase Model for Hydrothermal
-        Liquefaction of Algal Biomass. Green Chem. 2017, 19 (4), 1163–1174.
-        https://doi.org/10.1039/C6GC03294J.
-    [3] Li, Y.; Tarpeh, W. A.; Nelson, K. L.; Strathmann, T. J.
-        Quantitative Evaluation of an Integrated System for Valorization of
-        Wastewater Algae as Bio-Oil, Fuel Gas, and Fertilizer Products.
-        Environ. Sci. Technol. 2018, 52 (21), 12717–12727.
-        https://doi.org/10.1021/acs.est.8b04035.
-    [4] Jones, S. B.; Zhu, Y.; Anderson, D. B.; Hallen, R. T.; Elliott, D. C.; 
-        Schmidt, A. J.; Albrecht, K. O.; Hart, T. R.; Butcher, M. G.; Drennan, C.; 
-        Snowden-Swan, L. J.; Davis, R.; Kinchin, C. 
-        Process Design and Economics for the Conversion of Algal Biomass to
-        Hydrocarbons: Whole Algae Hydrothermal Liquefaction and Upgrading;
-        PNNL--23227, 1126336; 2014; https://doi.org/10.2172/1126336.
-    [5] Matayeva, A.; Rasmussen, S. R.; Biller, P. Distribution of Nutrients and
-        Phosphorus Recovery in Hydrothermal Liquefaction of Waste Streams.
-        BiomassBioenergy 2022, 156, 106323.
-        https://doi.org/10.1016/j.biombioe.2021.106323.
-    [6] Knorr, D.; Lukas, J.; Schoen, P. Production of Advanced Biofuels
+    [1] Knorr, D.; Lukas, J.; Schoen, P. Production of Advanced Biofuels
         via Liquefaction - Hydrothermal Liquefaction Reactor Design:
         April 5, 2013; NREL/SR-5100-60462, 1111191; 2013; p NREL/SR-5100-60462,
         1111191. https://doi.org/10.2172/1111191.
     '''
     _N_ins = 1
     _N_outs = 4
-    _units= {'Treatment capacity': 'lb/h',
-             'Solid filter and separator weight': 'lb'}
-    
-    auxiliary_unit_names=('heat_exchanger','kodrum')
+    _units = {
+        'Wet mass flowrate': 'lb/hr',
+        'Solid filter and separator weight': 'lb',
+        }
 
-    _F_BM_default = {**Reactor._F_BM_default,
-                     'Heat exchanger': 3.17}
+    auxiliary_unit_names = ('hx', 'inf_hx', 'eff_hx', 'kodrum')
+
+    _F_BM_default = {
+        **Reactor._F_BM_default,
+        'Heat exchanger': 3.17,
+        }
 
     def __init__(self, ID='', ins=None, outs=(), thermo=None,
-                 init_with='WasteStream',
-                 lipid_2_biocrude=0.846, # [1]
-                 protein_2_biocrude=0.445, # [1]
-                 carbo_2_biocrude=0.205, # [1]
-                 protein_2_gas=0.074, # [1]
-                 carbo_2_gas=0.418, # [1]
-                 biocrude_C_slope=-8.37, # [2]
-                 biocrude_C_intercept=68.55, # [2]
-                 biocrude_N_slope=0.133, # [2]
-                 biocrude_H_slope=-2.61, # [2]
-                 biocrude_H_intercept=8.20, # [2]
-                 HTLaqueous_C_slope=478, # [2]
-                 TOC_TC=0.764, # [3]
-                 hydrochar_C_slope=1.75, # [2]
-                 hydrochar_H_slope=0.141, # [2]
-                 biocrude_moisture_content=0.063, # [4]
-                 hydrochar_P_recovery_ratio=0.86, # [5]
-                 gas_composition={'CH4':0.050, 'C2H6':0.032,
-                                  'CO2':0.918}, # [4]
-                 hydrochar_pre=3029.7*6894.76, # [4]
-                 HTLaqueous_pre=30*6894.76, # [4]
-                 biocrude_pre=30*6894.76, # [4]
-                 offgas_pre=30*6894.76, # [4]
-                 eff_T=60+273.15, # [4]
-                 P=None, tau=15/60, V_wf=0.45,
-                 length_to_diameter=None, diameter=6.875*_in_to_m,
+                 init_with='WasteStream', include_construction=False,
+                 T=280+273.15,
+                 P=101325,
+                 dw_yields={
+                     'gas': 0,
+                     'aqueous': 0,
+                     'biocrude': 0,
+                     'char': 1,
+                     },
+                 gas_composition={'HTLgas': 1},
+                 aqueous_composition={'HTLaqueous': 1},
+                 biocrude_composition={'HTLbiocrude': 1},
+                 char_composition={'HTLchar': 1},
+                 internal_heat_exchanging=True,
+                 eff_T=60+273.15,
+                 eff_P=30*6894.76,
+                 use_decorated_cost=True,
+                 tau=15/60, V_wf=0.45,
+                 length_to_diameter=None,
+                 diameter=6.875*_in_to_m,
                  N=4, V=None, auxiliary=False,
                  mixing_intensity=None, kW_per_m3=0,
                  wall_thickness_factor=1,
                  vessel_material='Stainless steel 316',
                  vessel_type='Horizontal',
-                 CAPEX_factor=1,
-                 # this is equivalent to F_M = 2.1*2.7, which is a reasonable value for high-temperature, high-pressure, sludge-fed HTL reactors
-                 HTL_steel_cost_factor=2.7, # so the cost matches [6]
-                 mositure_adjustment_exist_in_the_system=False):
-        
-        SanUnit.__init__(self, ID, ins, outs, thermo, init_with)
-        self.lipid_2_biocrude = lipid_2_biocrude
-        self.protein_2_biocrude = protein_2_biocrude
-        self.carbo_2_biocrude = carbo_2_biocrude
-        self.protein_2_gas = protein_2_gas
-        self.carbo_2_gas = carbo_2_gas
-        self.biocrude_C_slope = biocrude_C_slope
-        self.biocrude_C_intercept = biocrude_C_intercept
-        self.biocrude_N_slope = biocrude_N_slope
-        self.biocrude_H_slope = biocrude_H_slope
-        self.biocrude_H_intercept = biocrude_H_intercept
-        self.HTLaqueous_C_slope = HTLaqueous_C_slope
-        self.TOC_TC = TOC_TC
-        self.hydrochar_C_slope = hydrochar_C_slope
-        self.hydrochar_H_slope = hydrochar_H_slope
-        self.biocrude_moisture_content = biocrude_moisture_content
-        self.hydrochar_P_recovery_ratio = hydrochar_P_recovery_ratio
-        self.gas_composition = gas_composition
-        self.hydrochar_pre = hydrochar_pre
-        self.HTLaqueous_pre = HTLaqueous_pre
-        self.biocrude_pre = biocrude_pre
-        self.offgas_pre = offgas_pre
-        hx_in = Stream(f'{ID}_hx_in')
-        hx_out = Stream(f'{ID}_hx_out')
-        self.heat_exchanger = HXutility(ID=f'.{ID}_hx', ins=hx_in, outs=hx_out, T=eff_T, rigorous=True)
-        self.kodrum = KnockOutDrum(ID=f'.{ID}_KOdrum')
+                 F_M={
+                     'Horizontal pressure vessel': 2.7,
+                     'Vertical pressure vessel': 2.7,
+                     },
+                 ):
+        SanUnit.__init__(self, ID, ins, outs, thermo, init_with,
+                          include_construction=include_construction)
+        self.T = T
         self.P = P
+        self.dw_yields = dw_yields
+        self.gas_composition = gas_composition
+        self.aqueous_composition = aqueous_composition
+        self.biocrude_composition = biocrude_composition
+        self.char_composition = char_composition
+        self.internal_heat_exchanging = internal_heat_exchanging
+        inf_pre_hx = Stream(f'{ID}_inf_pre_hx')
+        eff_pre_hx = Stream(f'{ID}_eff_pre_hx')
+        inf_after_hx = Stream(f'{ID}_inf_after_hx')
+        eff_after_hx = Stream(f'{ID}_eff_after_hx')
+        self.hx = HXprocess(ID=f'.{ID}_hx', ins=(inf_pre_hx, eff_pre_hx), outs=(inf_after_hx, eff_after_hx))
+        inf_hx_out = Stream(f'{ID}_inf_hx_out')
+        self.inf_hx = HXutility(ID=f'.{ID}_inf_hx', ins=inf_after_hx, outs=inf_hx_out, T=T, rigorous=True)
+        self._inf_at_temp = Stream(f'{ID}_inf_at_temp')
+        self._eff_at_temp = Stream(f'{ID}_eff_at_temp')
+        eff_hx_out = Stream(f'{ID}_eff_hx_out')
+        self.eff_T = eff_T
+        self.eff_P = eff_P
+        self.eff_hx = HXutility(ID=f'.{ID}_eff_hx', ins=eff_after_hx, outs=eff_hx_out, T=eff_T, rigorous=True)
+        self.use_decorated_cost = use_decorated_cost
+        if not use_decorated_cost:
+            self.kodrum = KnockOutDrum(ID=f'.{ID}_KOdrum', include_construction=include_construction)
+        else:
+            self.kodrum = None
         self.tau = tau
         self.V_wf = V_wf
         self.length_to_diameter = length_to_diameter
@@ -519,219 +523,165 @@ class HydrothermalLiquefaction(Reactor):
         self.mixing_intensity = mixing_intensity
         self.kW_per_m3 = kW_per_m3
         self.wall_thickness_factor = wall_thickness_factor
+        # See KnockOutDrum.__init__'s comment: F_M must be assigned before
+        # vessel_material, whose setter mutates F_M in place.
+        self.F_M = F_M
         self.vessel_material = vessel_material
         self.vessel_type = vessel_type
-        self.CAPEX_factor = CAPEX_factor
-        self.HTL_steel_cost_factor = HTL_steel_cost_factor
-        self.mositure_adjustment_exist_in_the_system = mositure_adjustment_exist_in_the_system
 
     def _run(self):
-        
-        dewatered_sludge = self.ins[0]
-        hydrochar, HTLaqueous, biocrude, offgas = self.outs
-        
-        if self.mositure_adjustment_exist_in_the_system == True:
-            self.WWTP = self.ins[0]._source.ins[0]._source.ins[0].\
-                             _source.ins[0]._source
-        else:
-            self.WWTP = self.ins[0]._source.ins[0]._source.ins[0]._source
-        
-        dewatered_sludge_afdw = dewatered_sludge.imass['Sludge_lipid'] +\
-                                dewatered_sludge.imass['Sludge_protein'] +\
-                                dewatered_sludge.imass['Sludge_carbo']
-        # just use afdw in revised MCA model, other places use dw
-        
-        self.afdw_lipid_ratio = self.WWTP.sludge_afdw_lipid
-        self.afdw_protein_ratio = self.WWTP.sludge_afdw_protein
-        self.afdw_carbo_ratio = self.WWTP.sludge_afdw_carbo
+        feed = self.ins[0]
+        gas, aq, crude, char = outs = self.outs
+        tot_dw = feed.F_mass - feed.imass['Water']
+        comps = (
+            self.gas_composition,
+            self.aqueous_composition,
+            self.biocrude_composition,
+            self.char_composition,
+            )
+        for out, comp in zip(outs, comps):
+            out.empty()
+            for k, v in comp.items():
+                out.imass[k] = v
 
-        # the following calculations are based on revised MCA model
-        hydrochar.imass['Hydrochar'] = 0.377*self.afdw_carbo_ratio*dewatered_sludge_afdw
-        
-        HTLaqueous.imass['HTLaqueous'] = (0.481*self.afdw_protein_ratio +\
-                                          0.154*self.afdw_lipid_ratio)*\
-                                          dewatered_sludge_afdw
-        # HTLaqueous is TDS in aqueous phase
-        # 0.377, 0.481, and 0.154 don't have uncertainties because they are calculated values
-         
-        gas_mass = (self.protein_2_gas*self.afdw_protein_ratio + self.carbo_2_gas*self.afdw_carbo_ratio)*\
-                       dewatered_sludge_afdw
-                       
-        for name, ratio in self.gas_composition.items():
-            offgas.imass[name] = gas_mass*ratio
-            
-        biocrude.imass['Biocrude'] = (self.protein_2_biocrude*self.afdw_protein_ratio +\
-                                      self.lipid_2_biocrude*self.afdw_lipid_ratio +\
-                                      self.carbo_2_biocrude*self.afdw_carbo_ratio)*\
-                                      dewatered_sludge_afdw
-        biocrude.imass['H2O'] = biocrude.imass['Biocrude']/(1 -\
-                                self.biocrude_moisture_content) -\
-                                biocrude.imass['Biocrude']
-                                
-        HTLaqueous.imass['H2O'] = dewatered_sludge.F_mass - hydrochar.F_mass -\
-                                  biocrude.F_mass - gas_mass - HTLaqueous.imass['HTLaqueous']
-        # assume ash (all soluble based on Jones) goes to water
-        
-        hydrochar.phase = 's'
-        offgas.phase = 'g'
-        HTLaqueous.phase = biocrude.phase = 'l'
-        
-        hydrochar.P = self.hydrochar_pre
-        HTLaqueous.P = self.HTLaqueous_pre
-        biocrude.P = self.biocrude_pre
-        offgas.P = self.offgas_pre
-        
-        for stream in self.outs : stream.T = self.heat_exchanger.T
-    
-    @property
-    def biocrude_yield(self):
-        return self.protein_2_biocrude*self.afdw_protein_ratio +\
-               self.lipid_2_biocrude*self.afdw_lipid_ratio +\
-               self.carbo_2_biocrude*self.afdw_carbo_ratio
-    
-    @property
-    def aqueous_yield(self):
-        return 0.481*self.afdw_protein_ratio + 0.154*self.afdw_lipid_ratio
-    
-    @property
-    def hydrochar_yield(self):
-        return 0.377*self.afdw_carbo_ratio
-    
-    @property
-    def gas_yield(self):
-        return self.protein_2_gas*self.afdw_protein_ratio + self.carbo_2_gas*self.afdw_carbo_ratio
-    
-    @property
-    def biocrude_C_ratio(self):
-        return (self.WWTP.AOSc*self.biocrude_C_slope + self.biocrude_C_intercept)/100 # [2]
-    
-    @property
-    def biocrude_H_ratio(self):
-        return (self.WWTP.AOSc*self.biocrude_H_slope + self.biocrude_H_intercept)/100 # [2]
-    
-    @property
-    def biocrude_N_ratio(self):
-        return self.biocrude_N_slope*self.WWTP.sludge_dw_protein # [2]
-    
-    @property
-    def biocrude_C(self):
-        return min(self.outs[2].F_mass*self.biocrude_C_ratio, self.WWTP.sludge_C)
-    
-    @property
-    def HTLaqueous_C(self):
-        return min(self.outs[1].F_vol*1000*self.HTLaqueous_C_slope*\
-                   self.WWTP.sludge_dw_protein*100/1000000/self.TOC_TC,
-                   self.WWTP.sludge_C - self.biocrude_C)
-    
-    @property
-    def biocrude_H(self):
-        return self.outs[2].F_mass*self.biocrude_H_ratio
-    
-    @property
-    def biocrude_N(self):
-        return min(self.outs[2].F_mass*self.biocrude_N_ratio, self.WWTP.sludge_N)
-    
-    # MJ/kg
-    @property
-    def biocrude_HHV(self):
-        return 30.74 - 8.52*self.WWTP.AOSc +\
-               0.024*self.WWTP.sludge_dw_protein # [2]
-    
-    @property
-    def energy_recovery(self):
-        return self.biocrude_HHV*self.outs[2].imass['Biocrude']/\
-               (self.WWTP.outs[0].F_mass -\
-               self.WWTP.outs[0].imass['H2O'])/self.WWTP.sludge_HHV # [2]
-    
-    @property
-    def offgas_C(self):
-        carbon = sum(self.outs[3].imass[self.gas_composition]*
-                     [cmp.i_C for cmp in self.components[self.gas_composition]])
-        return min(carbon, self.WWTP.sludge_C - self.biocrude_C - self.HTLaqueous_C)
-    
-    @property
-    def hydrochar_C_ratio(self):
-        return min(self.hydrochar_C_slope*self.WWTP.sludge_dw_carbo, 0.65) # [2]
-    
-    @property
-    def hydrochar_C(self):
-        return min(self.outs[0].F_mass*self.hydrochar_C_ratio, self.WWTP.sludge_C -\
-                   self.biocrude_C - self.HTLaqueous_C - self.offgas_C)
-    
-    @property
-    def hydrochar_P(self):
-        return min(self.WWTP.sludge_P*self.hydrochar_P_recovery_ratio, self.outs[0].F_mass)
-    
-    @property
-    def hydrochar_P_ratio(self):
-        return min(self.WWTP.sludge_P*self.hydrochar_P_recovery_ratio, self.outs[0].F_mass)/self.outs[0].F_mass
-    
-    @property
-    def hydrochar_H_ratio(self):
-        return self.hydrochar_H_slope*self.WWTP.sludge_dw_carbo
-    
-    @property
-    def hydrochar_O_ratio(self):
-        return 1 - self.hydrochar_C_ratio - self.hydrochar_P_ratio - self.hydrochar_H_ratio
-    
-    # assume no N and no ash in hydrochar
-    # MJ/kg
-    @property
-    def hydrochar_HHV(self):
-        return (0.338*self.hydrochar_C_ratio + 1.428*(self.hydrochar_H_ratio - self.hydrochar_O_ratio/8))*100
-    
-    @property
-    def HTLaqueous_N(self):
-        return self.WWTP.sludge_N - self.biocrude_N
-    
-    @property
-    def HTLaqueous_P(self):
-        return self.WWTP.sludge_P*(1 - self.hydrochar_P_recovery_ratio)
+        dw_yields = self.dw_yields
+        gas.F_mass = tot_dw * dw_yields['gas']
+        aq.F_mass = tot_dw * dw_yields['aqueous']
+        crude.F_mass = tot_dw * dw_yields['biocrude']
+        char.F_mass = tot_dw * dw_yields['char']
+
+        aq.imass['Water'] = feed.imass['Water'] - sum(i.imass['Water'] for i in (gas, crude, char))
+
+        for i in outs:
+            i.T = self.T
+            i.P = self.P
+
+        self._eff_at_temp.mix_from(outs)
+
+        gas.phase = 'g'
+        char.phase = 's'
+        aq.phase = crude.phase = 'l'
+
+        for attr, val in zip(('T', 'P'), (self.eff_T, self.eff_P)):
+            if val:
+                for i in self.outs: setattr(i, attr, val)
     
     def _design(self):
-        
-        Design = self.design_results
-        Design['Treatment capacity'] = self.ins[0].F_mass/_lb_to_kg
-        
-        hx = self.heat_exchanger
-        hx_ins0, hx_outs0 = hx.ins[0], hx.outs[0]
-        hx_ins0.mix_from((self.outs[1], self.outs[2], self.outs[3]))
-        hx_outs0.copy_like(hx_ins0)
-        hx_ins0.T = self.ins[0].T # temperature before/after HTL are similar
-        hx_outs0.T = hx.T
-        hx_ins0.P = hx_outs0.P = self.outs[0].P # cooling before depressurized, heating after pressurized
-        # in other words, both heating and cooling are performed under relatively high pressure
-        # hx_ins0.vle(T=hx_ins0.T, P=hx_ins0.P)
-        # hx_outs0.vle(T=hx_outs0.T, P=hx_outs0.P)
-        hx.simulate_as_auxiliary_exchanger(ins=hx.ins, outs=hx.outs)
+        hx = self.hx
+        inf_hx = self.inf_hx
+        inf_hx_in, inf_hx_out = inf_hx.ins[0], inf_hx.outs[0]
+        inf_pre_hx, eff_pre_hx = hx.ins
+        inf_after_hx, eff_after_hx = hx.outs
+        inf_pre_hx.copy_like(self.ins[0])
+        eff_pre_hx.copy_like(self._eff_at_temp)
 
-        self.P = self.ins[0].P
+        if self.internal_heat_exchanging:
+            hx.phase0 = hx.phase1 = 'l'
+            hx.T_lim1 = self.eff_T
+            hx.simulate()
+            for i in self.outs:
+                i.T = eff_after_hx.T
+        else:
+            hx.empty()
+            inf_after_hx.copy_like(inf_pre_hx)
+            eff_after_hx.copy_like(eff_pre_hx)
+
+        inf_hx_in.copy_like(inf_after_hx)
+        inf_hx_out.copy_flow(inf_hx_in)
+        # `copy_flow` only copies flow rates, not T/P
+        inf_hx_out.T = self.T
+        # No pressure drop is implied by this exchanger,
+        # so carry inf_hx_in.P through (mirroring Hydroprocessing._design's
+        # own inf_hx block below, which already does this).
+        inf_hx_out.P = inf_hx_in.P
+        inf_hx_in.vle(T=inf_hx_in.T, P=inf_hx_in.P)
+        inf_hx_out.vle(T=inf_hx_out.T, P=inf_hx_out.P)
+        inf_hx.simulate_as_auxiliary_exchanger(ins=inf_hx.ins, outs=inf_hx.outs)
+
+        eff_hx = self.eff_hx
+        eff_hx_in, eff_hx_out = eff_hx.ins[0], eff_hx.outs[0]
+        eff_hx_in.copy_like(eff_after_hx)
+        eff_hx_out.mix_from(self.outs)
+        # eff_hx_in/eff_hx_out share composition (this exchanger only cools
+        # or heats, it doesn't react), so simulate_as_auxiliary_exchanger's
+        # own duty auto-computation (outlet.Hnet - inlet.Hnet) already equals
+        # the correct sensible/latent duty.
+        eff_hx.simulate_as_auxiliary_exchanger(ins=eff_hx.ins, outs=eff_hx.outs)
+
         Reactor._design(self)
-        Design['Solid filter and separator weight'] = 0.2*Design['Weight']*Design['Number of reactors'] # assume stainless steel
-        # based on [6], case D design table, the purchase price of solid filter and separator to
-        # the purchase price of HTL reactor is around 0.2, therefore, assume the weight of solid filter
-        # and separator is 0.2*single HTL weight*number of HTL reactors
-        self.construction[0].quantity += Design['Solid filter and separator weight']*_lb_to_kg
-        
-        self.kodrum.V = self.F_mass_out/_lb_to_kg/1225236*4230/_m3_to_gal
-        # in [6], when knockout drum influent is 1225236 lb/hr, single knockout
-        # drum volume is 4230 gal
-        
-        self.kodrum.simulate()
-        
+
+        Design = self.design_results
+        Design['Solid filter and separator weight'] = 0.2*Design['Weight']*Design['Number of reactors']
+        if self.include_construction:
+            self.construction[0].quantity += Design['Solid filter and separator weight']*_lb_to_kg
+
+        if not self.use_decorated_cost:
+            kodrum = self.kodrum
+            kodrum.V = self.F_mass_out/_lb_to_kg/1225236*4230/_m3_to_gal
+            kodrum.simulate()
+
     def _cost(self):
-        Reactor._cost(self)
-        self._decorated_cost()
-        
-        purchase_costs = self.baseline_purchase_costs
-        for item in purchase_costs.keys():
-            purchase_costs[item] *= self.CAPEX_factor
-            
-        purchase_costs['Horizontal pressure vessel'] *= self.HTL_steel_cost_factor
-        
-        for aux_unit in self.auxiliary_units:
-            purchase_costs = aux_unit.baseline_purchase_costs
-            installed_costs = aux_unit.installed_costs
-            for item in purchase_costs.keys():
-                purchase_costs[item] *= self.CAPEX_factor
-                installed_costs[item] *= self.CAPEX_factor
+        self.baseline_purchase_costs.clear()
+        if self.use_decorated_cost:
+            Design = self.design_results
+            Design.clear()
+            ins0 = self.ins[0]
+            Design['Wet mass flowrate'] = ins0.F_mass/_lb_to_kg
+            self._decorated_cost()
+        else:
+            # `Reactor._cost` reads `design_results['Total volume']`, populated by
+            # `_design`'s `Reactor._design(self)` call -- must not be cleared here.
+            Reactor._cost(self)
+
+    def _normalize_composition(self, dct):
+        total = sum(dct.values())
+        if total <= 0: raise ValueError(f'Sum of total yields/compositions should be positive, not {total}.')
+        return {k: v/total for k, v in dct.items()}
+
+    @property
+    def dw_yields(self):
+        return self._dw_yields
+    @dw_yields.setter
+    def dw_yields(self, comp_dct):
+        self._dw_yields = self._normalize_composition(comp_dct)
+
+    @property
+    def gas_composition(self):
+        return self._gas_composition
+    @gas_composition.setter
+    def gas_composition(self, comp_dct):
+        self._gas_composition = self._normalize_composition(comp_dct)
+
+    @property
+    def aqueous_composition(self):
+        return self._aqueous_composition
+    @aqueous_composition.setter
+    def aqueous_composition(self, comp_dct):
+        self._aqueous_composition = self._normalize_composition(comp_dct)
+
+    @property
+    def biocrude_composition(self):
+        return self._biocrude_composition
+    @biocrude_composition.setter
+    def biocrude_composition(self, comp_dct):
+        self._biocrude_composition = self._normalize_composition(comp_dct)
+
+    @property
+    def char_composition(self):
+        return self._char_composition
+    @char_composition.setter
+    def char_composition(self, comp_dct):
+        self._char_composition = self._normalize_composition(comp_dct)
+
+    @property
+    def biocrude_HHV(self):
+        '''[float] Higher heating value of the biocrude, MJ/kg.'''
+        crude = self.outs[2]
+        return crude.HHV/crude.F_mass/1e3
+
+    @property
+    def energy_recovery(self):
+        '''[float] Fraction of the feedstock's HHV recovered in the biocrude.'''
+        feed = self.ins[0]
+        crude = self.outs[2]
+        return crude.HHV/feed.HHV

--- a/tests/test_auxiliary_unit_names.py
+++ b/tests/test_auxiliary_unit_names.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+'''
+QSDsan: Quantitative Sustainable Design for sanitation and resource recovery systems
+
+This module is developed by:
+
+    Yalin Li <mailto.yalin.li@gmail.com>
+
+This module is under the University of Illinois/NCSA Open Source License.
+Please refer to https://github.com/QSD-Group/QSDsan/blob/main/LICENSE.txt
+for license details.
+'''
+
+__all__ = ('test_auxiliary_unit_names_match_attributes',)
+
+
+def test_auxiliary_unit_names_match_attributes():
+    '''
+    For every `SanUnit` subclass declaring a non-empty `auxiliary_unit_names`,
+    each declared name must be assigned via `self.<name> = ...` somewhere in
+    the class's methods (e.g., `__init__`, `_setup`, or other lifecycle methods)
+    Otherwise BioSTEAM's `auxiliary_units` silently drops it (`getattr(self, name, None)`
+    returns `None` with no error) without raising.
+    '''
+    import ast, inspect
+    from textwrap import dedent
+    import qsdsan as qs
+
+    modules = [m for m in (getattr(qs, 'unit_operations', None),
+                            getattr(qs, 'sanunits', None)) if m is not None]
+    seen = {}
+    for module in modules:
+        for name in dir(module):
+            obj = getattr(module, name)
+            if isinstance(obj, type) and issubclass(obj, qs.SanUnit):
+                seen[obj] = obj.__name__
+
+    def assigned_attrs(cls):
+        attrs = set()
+        for klass in cls.__mro__:
+            for method_name, member in klass.__dict__.items():
+                if not callable(member):
+                    continue
+                try:
+                    source = inspect.getsource(member)
+                except (OSError, TypeError):
+                    continue
+                try:
+                    tree = ast.parse(dedent(source))
+                except (SyntaxError, IndentationError):
+                    continue
+                for node in ast.walk(tree):
+                    # Direct assignment: self.attr = ...
+                    if (isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Store)
+                            and isinstance(node.value, ast.Name) and node.value.id == 'self'):
+                        attrs.add(node.attr)
+                    # Auxiliary unit registration: self.auxiliary('attr', ...)
+                    elif (isinstance(node, ast.Call)
+                            and isinstance(node.func, ast.Attribute)
+                            and node.func.attr == 'auxiliary'
+                            and isinstance(node.func.value, ast.Name)
+                            and node.func.value.id == 'self'
+                            and node.args
+                            and isinstance(node.args[0], ast.Constant)):
+                        attrs.add(node.args[0].value)
+        return attrs
+
+    # (class name, attr name): accepted because BioSTEAM's `auxiliary_units`
+    # property does `unit = getattr(self, name, None); if unit is None: continue`
+    # -- an unassigned declared name contributes zero cost/utility/construction,
+    # not a silently wrong one, so this is a dead declaration, not a live bug.
+    accepted_unused = {
+        ('MESHDistillation', 'vacuum_system'), # never assigned anywhere in
+        # BioSTEAM's MESHDistillation/its MRO; confirmed no _cost_vacuum()
+        # method exists to assign it either.
+        }
+
+    bad = []
+    for cls, name in seen.items():
+        aux_names = getattr(cls, 'auxiliary_unit_names', ())
+        if not aux_names: continue
+        missing = [n for n in aux_names if n not in assigned_attrs(cls)
+                   and (name, n) not in accepted_unused]
+        if missing: bad.append((name, missing))
+
+    assert not bad, (
+        'these unit classes declare `auxiliary_unit_names` entries never '
+        f'assigned as `self.<name> = ...` in any method: {bad}'
+        )
+
+
+if __name__ == '__main__':
+    test_auxiliary_unit_names_match_attributes()


### PR DESCRIPTION
See #125, now moved the `HydrothermalLiquefaction` and `Hydroprocess` (covering both `Hydrocracking` and `Hydrotreating` of `exposan.saf` here. The original sludge-specific implementations were moved to `exposan.htl`.